### PR TITLE
Ensure visibility is true or false

### DIFF
--- a/lib/alexandria/ui/listview.rb
+++ b/lib/alexandria/ui/listview.rb
@@ -204,7 +204,7 @@ module Alexandria
         ]
         cols = @listview.columns[1..-1] # skip "Title"
         cols.each_index do |i|
-          cols[i].visible = cols_visibility[i]
+          cols[i].visible = !cols_visibility[i].nil?
         end
         log.debug { 'Columns visibility: ' + cols.map { |col| "#{col.title} #{col.visible?}" }.join(', ') }
       end


### PR DESCRIPTION
Fixes #20 

Alexandria crashes on boot with Glib2 `Gtk::TreeviewColumn.visible` needs to be set to `true` or `false` but it is being set to `nil` in some cases.

Note, this is not a complete fix because similar problems, where a boolean value is being set to `nul`, occurs in other places and I haven't got round to finding them all yet. I have raised this PR to show what the solution might be but I do not think that it is ready to be merged yet.