### PR TITLE
Set initial visibility for dialogs to False

### DIFF
--- a/share/alexandria/glade/acquire_dialog__builder.glade
+++ b/share/alexandria/glade/acquire_dialog__builder.glade
@@ -3,7 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="acquire_dialog">
-    <property name="visible">True</property>
+    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
     <property name="title" translatable="yes">Acquire from Scanner</property>

--- a/share/alexandria/glade/book_properties_dialog__builder.glade
+++ b/share/alexandria/glade/book_properties_dialog__builder.glade
@@ -3,7 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="book_properties_dialog">
-    <property name="visible">True</property>
+    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>

--- a/share/alexandria/glade/new_book_dialog__builder.glade
+++ b/share/alexandria/glade/new_book_dialog__builder.glade
@@ -26,7 +26,7 @@
     </data>
   </object>
   <object class="GtkDialog" id="new_book_dialog">
-    <property name="visible">True</property>
+    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="border_width">8</property>
     <property name="title" translatable="yes">Adding a Book</property>

--- a/share/alexandria/glade/preferences_dialog__builder.glade
+++ b/share/alexandria/glade/preferences_dialog__builder.glade
@@ -3,7 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="preferences_dialog">
-    <property name="visible">True</property>
+    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
     <property name="type_hint">dialog</property>


### PR DESCRIPTION
This should silence warnings about "GtkDialog mapped without a transient parent. This is discouraged."