### PR TITLE
Fix crash on export

### DIFF
--- a/lib/alexandria/ui/export_dialog.rb
+++ b/lib/alexandria/ui/export_dialog.rb
@@ -108,8 +108,6 @@ module Alexandria
       private
 
       def on_export(format, theme)
-        raise NotImplementedError unless @library.respond_to?(format.message)
-
         filename = self.filename
         if format.ext
           filename += "." + format.ext if File.extname(filename).empty?


### PR DESCRIPTION
Just assume library formats are defined properly instead of aborting early. Somehow this detection of defined formats didn't work properly.

This fixes #38.