### PR TITLE
Remove use of SimpleDelegator

### DIFF
--- a/lib/alexandria/book_providers.rb
+++ b/lib/alexandria/book_providers.rb
@@ -84,7 +84,7 @@ module Alexandria
           trace = ex.backtrace.join("\n >")
           log.warn { "Provider #{factory.name} encountered error: #{ex.message} #{trace}" }
         end
-        if last == factory
+        if factory == instance.last
           log.warn { "Error while searching #{criterion}" }
           message = case ex
                     when Timeout::Error

--- a/lib/alexandria/book_providers.rb
+++ b/lib/alexandria/book_providers.rb
@@ -216,15 +216,15 @@ module Alexandria
       end
 
       def reinitialize(fullname)
-        @name << "_" << fullname.hash.to_s
+        @name = "#{name}_#{fullname.hash.to_s}"
         @fullname = fullname
         prefs = Alexandria::Preferences.instance
         ary = prefs.get_variable :abstract_providers
         ary ||= []
         ary << @name
         prefs.set_variable :abstract_providers, ary
-        message = variable_name("name") + "="
-        prefs.send(message, @fullname)
+        message = variable_name("name")
+        prefs.set_variable(message, @fullname)
       end
 
       def remove

--- a/lib/alexandria/book_providers/z3950.rb
+++ b/lib/alexandria/book_providers/z3950.rb
@@ -81,7 +81,7 @@ module Alexandria
         raise NoResultsError
       end
 
-      def marc_to_book(marc_txt)
+      def marc_to_book(marc_txt, isbn)
         begin
           marc = MARC::Record.new_from_marc(marc_txt, forgiving: true)
         rescue StandardError => ex
@@ -109,7 +109,7 @@ module Alexandria
 
         return if marc.title.nil? # or marc.authors.empty?
 
-        (isbn = isbn) || marc.isbn
+        isbn = isbn || marc.isbn
         isbn = Library.canonicalise_ean(isbn)
 
         book = Book.new(marc.title, marc.authors,
@@ -120,7 +120,7 @@ module Alexandria
         book
       end
 
-      def books_from_marc(resultset, _isbn)
+      def books_from_marc(resultset, isbn)
         results = []
         resultset[0..9].each do |record|
           marc_txt = record.render(prefs["charset"], "UTF-8")
@@ -141,7 +141,7 @@ module Alexandria
                                                                   mappings)
             if book.nil?
               # failing that, try the genuine MARC parser
-              book = marc_to_book(marc_txt)
+              book = marc_to_book(marc_txt, isbn)
             end
           rescue StandardError => ex
             log.warn { ex }

--- a/lib/alexandria/import_library.rb
+++ b/lib/alexandria/import_library.rb
@@ -106,13 +106,7 @@ module Alexandria
           book_elements += keys.map do |key|
             neaten(elements[key].text) if elements[key]
           end
-          # isbn
-          if book_elements[2].nil? || book_elements[2].strip.empty?
-            book_elements[2] = nil
-          else
-            book_elements[2] = book_elements[2].strip
-            book_elements[2] = Library.canonicalise_ean(book_elements[2])
-          end
+          book_elements[2] = Library.canonicalise_ean(book_elements[2])
           # publishing_year
           book_elements[4] = book_elements[4].to_i unless book_elements[4].nil?
           log.debug { book_elements.inspect }

--- a/lib/alexandria/import_library.rb
+++ b/lib/alexandria/import_library.rb
@@ -131,9 +131,7 @@ module Alexandria
         # TODO: Pass in library store as an argument
         library = LibraryCollection.instance.library_store.load_library name
         content.each do |book, cover|
-          unless cover.nil?
-            library.save_cover(book, File.join(Dir.pwd, "images", cover))
-          end
+          library.save_cover(book, File.join(Dir.pwd, "images", cover)) unless cover.nil?
           library << book
           library.save(book)
         end

--- a/lib/alexandria/import_library.rb
+++ b/lib/alexandria/import_library.rb
@@ -127,12 +127,11 @@ module Alexandria
           on_iterate_cb&.call(n + 1, total)
         end
 
-        library = Library.load(name)
+        # TODO: Pass in library store as an argument
+        library = LibraryCollection.instance.library_store.load_library name
         content.each do |book, cover|
           unless cover.nil?
-            library.save_cover(book,
-                               File.join(Dir.pwd, "images",
-                                         cover))
+            library.save_cover(book, File.join(Dir.pwd, "images", cover))
           end
           library << book
           library.save(book)
@@ -164,7 +163,7 @@ module Alexandria
           if book.isbn
             # if we can search by ISBN, try to grab the cover
             begin
-              dl_book, dl_cover = Alexandria::BookProviders.isbn_search(book.isbn)
+              dl_book, dl_cover = BookProviders.isbn_search(book.isbn)
               if dl_book.authors.size > book.authors.size
                 # LibraryThing only supports a single author, so
                 # attempt to include more author information if it's
@@ -202,7 +201,8 @@ module Alexandria
         end
       end
 
-      library = Library.load(name)
+      # TODO: Pass in library store as an argument
+      library = LibraryCollection.instance.library_store.load_library name
 
       books_and_covers.each do |book, cover_uri|
         log.debug { "Saving #{book.isbn} cover" }
@@ -219,13 +219,7 @@ module Alexandria
       log.debug { "Starting import_as_isbn_list... " }
       isbn_list = IO.readlines(filename).map do |line|
         log.debug { "Trying line #{line}" }
-        # Let's preserve the failing isbns so we can report them later.
-        begin
-          [line.chomp, canonicalise_isbn(line.chomp)] unless line == "\n"
-        rescue StandardError => ex
-          log.debug { ex.message }
-          [line.chomp, nil]
-        end
+        [line.chomp, canonicalise_isbn(line.chomp)] unless line == "\n"
       end
       log.debug { "Isbn list: #{isbn_list.inspect}" }
       isbn_list.compact!
@@ -239,11 +233,11 @@ module Alexandria
       isbn_list.each do |isbn|
         begin
           if isbn[1]
-            books << Alexandria::BookProviders.isbn_search(isbn[1])
+            books << BookProviders.isbn_search(isbn[1])
           else
             bad_isbns << isbn[0]
           end
-        rescue StandardError => ex
+        rescue BookProviders::SearchEmptyError => ex
           log.debug { ex.message }
           failed_lookup_isbns << isbn[1]
           log.debug { "NOTE : ignoring on_error_cb #{on_error_cb}" }
@@ -254,7 +248,10 @@ module Alexandria
         on_iterate_cb&.call(current_iteration += 1, max_iterations)
       end
       log.debug { "Bad Isbn list: #{bad_isbns.inspect}" } if bad_isbns
-      library = load(name)
+
+      # TODO: Pass in library store as an argument
+      library = LibraryCollection.instance.library_store.load_library name
+
       log.debug { "Going with these #{books.length} books: #{books.inspect}" }
       books.each do |book, cover_uri|
         log.debug { "Saving #{book.isbn} cover..." }

--- a/lib/alexandria/import_library.rb
+++ b/lib/alexandria/import_library.rb
@@ -11,6 +11,7 @@ module Alexandria
   class ImportFilter
     attr_reader :name, :patterns, :message
 
+    include Logging
     include GetText
     extend GetText
     bindtextdomain(Alexandria::TEXTDOMAIN, charset: "UTF-8")

--- a/lib/alexandria/import_library_csv.rb
+++ b/lib/alexandria/import_library_csv.rb
@@ -72,8 +72,7 @@ module Alexandria
       additional.split(",").each do |add|
         authors << normalize(add)
       end
-      isbn = row[@isbn] # TODO: canonicalize_ean...
-      isbn = Library.canonicalise_ean(isbn) if isbn
+      isbn = Library.canonicalise_ean(row[@isbn])
       publisher = normalize(row[@publisher])
       year = row[@publishing_year].to_i
       edition = normalize(row[@edition])

--- a/lib/alexandria/ui/alert_dialog.rb
+++ b/lib/alexandria/ui/alert_dialog.rb
@@ -6,20 +6,17 @@
 
 module Alexandria
   module UI
-    class AlertDialog < SimpleDelegator
+    class AlertDialog
       def initialize(parent, title, stock_icon, buttons, message = nil)
-        dialog = Gtk::Dialog.new(title: "", parent: parent, flags: :destroy_with_parent,
-                                 buttons: buttons)
-        super(dialog)
-
-        self.border_width = 6
-        self.resizable = false
-        child.spacing = 12
+        @dialog = Gtk::Dialog.new(title: "", parent: parent, flags: :destroy_with_parent,
+                                  buttons: buttons)
+        @dialog.border_width = 6
+        @dialog.resizable = false
+        @dialog.child.spacing = 12
 
         hbox = Gtk::Box.new(:horizontal, 12)
         hbox.homogeneous = false
         hbox.border_width = 6
-        child.pack_start(hbox)
 
         image = Gtk::Image.new(stock: stock_icon,
                                size: Gtk::IconSize::DIALOG)
@@ -28,11 +25,28 @@ module Alexandria
 
         vbox = Gtk::Box.new(:vertical, 6)
         vbox.homogeneous = false
-        hbox.pack_start(vbox)
-
         vbox.pack_start make_label("<b><big>#{title}</big></b>")
         vbox.pack_start make_label(message.strip) unless message
+        hbox.pack_start(vbox)
+
+        @dialog.child.pack_start(hbox)
       end
+
+      def show_all
+        dialog.show_all
+      end
+
+      def run
+        dialog.run
+      end
+
+      def destroy
+        dialog.destroy
+      end
+
+      private
+
+      attr_reader :dialog
 
       def make_label(markup)
         label = Gtk::Label.new

--- a/lib/alexandria/ui/alert_dialog.rb
+++ b/lib/alexandria/ui/alert_dialog.rb
@@ -44,6 +44,10 @@ module Alexandria
         dialog.destroy
       end
 
+      def default_response=(response)
+        dialog.default_response = response
+      end
+
       private
 
       attr_reader :dialog

--- a/lib/alexandria/ui/bad_isbns_dialog.rb
+++ b/lib/alexandria/ui/bad_isbns_dialog.rb
@@ -8,17 +8,16 @@ module Alexandria
   module UI
     # Generalized Dialog for lists of bad isbns. Used for on_import. Can also
     # be used for on_load library conversions.
-    class BadIsbnsDialog < SimpleDelegator
+    class BadIsbnsDialog
       def initialize(parent, message, list)
-        dialog = Gtk::MessageDialog.new(parent: parent,
-                                        flags: :modal,
-                                        type: :warning,
-                                        buttons: :close,
-                                        message: message)
-        super(dialog)
+        @dialog = Gtk::MessageDialog.new(parent: parent,
+                                         flags: :modal,
+                                         type: :warning,
+                                         buttons: :close,
+                                         message: message)
+        the_vbox = @dialog.children.first
 
         isbn_container = Gtk::Box.new :horizontal
-        the_vbox = children.first
         the_vbox.pack_start(isbn_container)
         the_vbox.reorder_child(isbn_container, 3)
         scrolley = Gtk::ScrolledWindow.new
@@ -30,7 +29,12 @@ module Alexandria
         list.each do |li|
           textview.buffer.insert_at_cursor("#{li}\n")
         end
-        show_all
+
+        @dialog.signal_connect("response") { @dialog.destroy }
+      end
+
+      def show
+        @dialog.show_all
       end
     end
   end

--- a/lib/alexandria/ui/callbacks.rb
+++ b/lib/alexandria/ui/callbacks.rb
@@ -55,14 +55,12 @@ module Alexandria
           unless bad_isbns.empty?
             log.debug { "bad_isbn" }
             message = _("The following lines are not valid ISBNs and were not imported:")
-            bad_isbn_warn = BadIsbnsDialog.new(@main_app, message, bad_isbns)
-            bad_isbn_warn.signal_connect("response") { bad_isbn_warn.destroy }
+            BadIsbnsDialog.new(@main_app, message, bad_isbns).show
           end
           unless failed_isbns.nil? || failed_isbns.empty?
             log.debug { "failed lookup of #{failed_isbns.size} ISBNs" }
             message = _("Books could not be found for the following ISBNs:")
-            failed_lookup = BadIsbnsDialog.new(@main_app, message, failed_isbns)
-            failed_lookup.signal_connect("response") { failed_lookup.destroy }
+            BadIsbnsDialog.new(@main_app, message, failed_isbns).show
           end
           @libraries.add_library(library)
           append_library(library, true)

--- a/lib/alexandria/ui/confirm_erase_dialog.rb
+++ b/lib/alexandria/ui/confirm_erase_dialog.rb
@@ -20,7 +20,7 @@ module Alexandria
               _("A file named '%s' already exists.  Do you want " \
                 "to replace it with the one you are generating?") % filename)
         # FIXME: Should accept just :cancel
-        self.default_response = Gtk::ResponseType::CANCEL
+        dialog.default_response = Gtk::ResponseType::CANCEL
       end
 
       def erase?

--- a/lib/alexandria/ui/conflict_while_copying_dialog.rb
+++ b/lib/alexandria/ui/conflict_while_copying_dialog.rb
@@ -21,7 +21,7 @@ module Alexandria
                [_("_Replace"), Gtk::ResponseType::OK]],
               _("If you replace the existing book, its contents will " \
                 "be overwritten."))
-        self.default_response = Gtk::ResponseType::CANCEL
+        dialog.default_response = Gtk::ResponseType::CANCEL
       end
 
       def replace?

--- a/lib/alexandria/ui/error_dialog.rb
+++ b/lib/alexandria/ui/error_dialog.rb
@@ -13,7 +13,7 @@ module Alexandria
         super(parent, title, Gtk::Stock::DIALOG_ERROR,
               [[Gtk::Stock::OK, :ok]], message)
         # FIXME: Should accept just :ok
-        self.default_response = Gtk::ResponseType::OK
+        dialog.default_response = Gtk::ResponseType::OK
       end
 
       def display

--- a/lib/alexandria/ui/export_dialog.rb
+++ b/lib/alexandria/ui/export_dialog.rb
@@ -20,11 +20,11 @@ module Alexandria
 
       def initialize(parent, library, sort_order)
         @dialog = Gtk::FileChooserDialog.new(title: _("Export '%s'") % library.name,
-                                                    parent: parent,
-                                                    action: :save,
-                                                    buttons: [[Gtk::Stock::HELP, :help],
-                                                              [Gtk::Stock::CANCEL, :cancel],
-                                                              [_("_Export"), :accept]])
+                                             parent: parent,
+                                             action: :save,
+                                             buttons: [[Gtk::Stock::HELP, :help],
+                                                       [Gtk::Stock::CANCEL, :cancel],
+                                                       [_("_Export"), :accept]])
         @dialog.current_name = library.name
         @dialog.signal_connect("destroy") { @dialog.hide }
 

--- a/lib/alexandria/ui/import_dialog.rb
+++ b/lib/alexandria/ui/import_dialog.rb
@@ -9,7 +9,7 @@ require "alexandria/ui/skip_entry_dialog"
 
 module Alexandria
   module UI
-    class ImportDialog < SimpleDelegator
+    class ImportDialog
       include GetText
       include Logging
 
@@ -17,49 +17,50 @@ module Alexandria
 
       FILTERS = Alexandria::ImportFilter.all
 
+      attr_reader :dialog
+
       def initialize(parent)
         title = _("Import a Library")
-        dialog = Gtk::FileChooserDialog.new title: title, parent: parent, action: :open
-        super(dialog)
+        @dialog = Gtk::FileChooserDialog.new title: title, parent: parent, action: :open
         log.debug { "ImportDialog opened" }
         @destroyed = false
         @running = false
-        add_button(Gtk::Stock::HELP, Gtk::ResponseType::HELP)
-        add_button(Gtk::Stock::CANCEL, Gtk::ResponseType::CANCEL)
-        import_button = add_button(_("_Import"),
-                                   Gtk::ResponseType::ACCEPT)
+        dialog.add_button(Gtk::Stock::HELP, Gtk::ResponseType::HELP)
+        dialog.add_button(Gtk::Stock::CANCEL, Gtk::ResponseType::CANCEL)
+        import_button = dialog.add_button(_("_Import"),
+                                          Gtk::ResponseType::ACCEPT)
         import_button.sensitive = false
 
-        signal_connect("destroy") do
+        dialog.signal_connect("destroy") do
           if @running
             @destroyed = true
           else
-            destroy
+            dialog.destroy
           end
         end
 
         filters = {}
         FILTERS.each do |filter|
           filefilter = make_filefilter filter
-          add_filter(filefilter)
+          dialog.add_filter(filefilter)
           log.debug { "Added ImportFilter #{filefilter} -- #{filefilter.name}" }
           filters[filefilter] = filter
         end
 
-        signal_connect("selection_changed") do
+        dialog.signal_connect("selection_changed") do
           import_button.sensitive = filename && File.file?(filename)
         end
 
         # before adding the (hidden) progress bar, we must re-set the
         # packing of the button box (currently packed at the end),
         # because the progressbar will be *after* the button box.
-        buttonbox = child.children.last
-        child.set_child_packing(buttonbox, pack_type: :start)
-        child.reorder_child(buttonbox, 1)
+        buttonbox = dialog.child.children.last
+        dialog.child.set_child_packing(buttonbox, pack_type: :start)
+        dialog.child.reorder_child(buttonbox, 1)
 
         pbar = Gtk::ProgressBar.new
         pbar.show_text = true
-        child.pack_start(pbar, expand: false)
+        dialog.child.pack_start(pbar, expand: false)
       end
 
       def acquire
@@ -75,7 +76,7 @@ module Alexandria
         exec_queue = ExecutionQueue.new
 
         while !@destroyed &&
-            ((response = run) != Gtk::ResponseType::CANCEL) &&
+            ((response = dialog.run) != Gtk::ResponseType::CANCEL) &&
             response != Gtk::ResponseType::DELETE_EVENT
 
           if response == Gtk::ResponseType::HELP
@@ -110,8 +111,8 @@ module Alexandria
           @bad_isbns = nil
           @failed_isbns = nil
           thread = Thread.start do
-            library, @bad_isbns, @failed_isbns = filter.invoke(new_library_name,
-                                                               filename)
+            library, @bad_isbns, @failed_isbns =
+              filter.invoke(new_library_name, filename)
           rescue StandardError => ex
             trace = ex.backtrace.join("\n> ")
             log.error { "Import failed: #{ex.message} #{trace}" }
@@ -139,7 +140,8 @@ module Alexandria
             self.sensitive = true
           end
         end
-        destroy unless @destroyed
+
+        dialog.destroy unless @destroyed
       end
 
       private

--- a/lib/alexandria/ui/keep_bad_isbn_dialog.rb
+++ b/lib/alexandria/ui/keep_bad_isbn_dialog.rb
@@ -22,7 +22,7 @@ module Alexandria
               Gtk::Stock::DIALOG_QUESTION,
               [[Gtk::Stock::CANCEL, Gtk::ResponseType::CANCEL],
                [_("_Keep"), Gtk::ResponseType::OK]], message)
-        self.default_response = Gtk::ResponseType::OK
+        dialog.default_response = Gtk::ResponseType::OK
       end
 
       def keep?

--- a/lib/alexandria/ui/new_provider_dialog.rb
+++ b/lib/alexandria/ui/new_provider_dialog.rb
@@ -17,14 +17,14 @@ module Alexandria
               parent: parent,
               flags: :modal,
               buttons: [[Gtk::Stock::CANCEL, Gtk::ResponseType::CANCEL]])
-        @add_button = add_button(Gtk::Stock::ADD,
-                                 Gtk::ResponseType::ACCEPT)
+        @add_button = dialog.add_button(Gtk::Stock::ADD,
+                                        Gtk::ResponseType::ACCEPT)
 
         instances = BookProviders.abstract_classes.map(&:new)
         @selected_instance = nil
 
         @table = Gtk::Table.new(2, 2)
-        child.pack_start(@table)
+        dialog.child.pack_start(@table)
 
         # Name.
 

--- a/lib/alexandria/ui/new_provider_dialog.rb
+++ b/lib/alexandria/ui/new_provider_dialog.rb
@@ -33,10 +33,10 @@ module Alexandria
         label_name.xalign = 0
         @table.attach_defaults(label_name, 0, 1, 0, 1)
 
-        entry_name = Gtk::Entry.new
-        entry_name.mandatory = true
-        label_name.mnemonic_widget = entry_name
-        @table.attach_defaults(entry_name, 1, 2, 0, 1)
+        @entry_name = Gtk::Entry.new
+        @entry_name.mandatory = true
+        label_name.mnemonic_widget = @entry_name
+        @table.attach_defaults(@entry_name, 1, 2, 0, 1)
 
         # Type.
 
@@ -62,14 +62,14 @@ module Alexandria
       end
 
       def acquire
-        show_all
-        if run == Gtk::ResponseType::ACCEPT
-          @selected_instance.reinitialize(entry_name.text)
+        dialog.show_all
+        if dialog.run == Gtk::ResponseType::ACCEPT
+          @selected_instance.reinitialize(@entry_name.text)
           sync_variables
         else
           @selected_instance = nil
         end
-        destroy
+        dialog.destroy
         instance
       end
 

--- a/lib/alexandria/ui/new_smart_library_dialog.rb
+++ b/lib/alexandria/ui/new_smart_library_dialog.rb
@@ -13,20 +13,20 @@ module Alexandria
       def initialize(parent)
         super(parent)
 
-        @dialog.add_buttons([Gtk::Stock::CANCEL, :cancel],
-                    [Gtk::Stock::NEW, :ok])
+        dialog.add_buttons([Gtk::Stock::CANCEL, :cancel],
+                           [Gtk::Stock::NEW, :ok])
 
-        @dialog.title = _("New Smart Library")
+        dialog.title = _("New Smart Library")
         # FIXME: Should accept just :cancel
-        @dialog.default_response = Gtk::ResponseType::CANCEL
+        dialog.default_response = Gtk::ResponseType::CANCEL
         insert_new_rule
       end
 
       def acquire
-        show_all
+        dialog.show_all
 
         result = nil
-        while ((response = run) != Gtk::ResponseType::CANCEL) &&
+        while ((response = dialog.run) != Gtk::ResponseType::CANCEL) &&
             (response != Gtk::ResponseType::DELETE_EVENT)
 
           if response == Gtk::ResponseType::HELP
@@ -37,9 +37,11 @@ module Alexandria
           end
         end
 
-        destroy
+        dialog.destroy
         result
       end
+
+      private
 
       def handle_help_response
         Alexandria::UI.display_help(self, "new-smart-library")
@@ -60,8 +62,6 @@ module Alexandria
                                    library_store)
         library
       end
-
-      private
 
       def smart_library_base_name(rules)
         return unless rules.length == 1

--- a/lib/alexandria/ui/new_smart_library_dialog.rb
+++ b/lib/alexandria/ui/new_smart_library_dialog.rb
@@ -13,12 +13,12 @@ module Alexandria
       def initialize(parent)
         super(parent)
 
-        add_buttons([Gtk::Stock::CANCEL, :cancel],
+        @dialog.add_buttons([Gtk::Stock::CANCEL, :cancel],
                     [Gtk::Stock::NEW, :ok])
 
-        self.title = _("New Smart Library")
+        @dialog.title = _("New Smart Library")
         # FIXME: Should accept just :cancel
-        self.default_response = Gtk::ResponseType::CANCEL
+        @dialog.default_response = Gtk::ResponseType::CANCEL
         insert_new_rule
       end
 

--- a/lib/alexandria/ui/provider_preferences_base_dialog.rb
+++ b/lib/alexandria/ui/provider_preferences_base_dialog.rb
@@ -15,6 +15,8 @@ end
 module Alexandria
   module UI
     class ProviderPreferencesBaseDialog
+      attr_reader :dialog
+
       def initialize(title:, parent:, flags:, buttons:)
         @dialog = Gtk::Dialog.new(title: title, parent: parent, flags: flags,
                                  buttons: buttons)
@@ -26,8 +28,6 @@ module Alexandria
       end
 
       private
-
-      attr_reader :dialog
 
       def fill_table(table, provider)
         i = table.n_rows

--- a/lib/alexandria/ui/provider_preferences_base_dialog.rb
+++ b/lib/alexandria/ui/provider_preferences_base_dialog.rb
@@ -14,17 +14,20 @@ end
 
 module Alexandria
   module UI
-    class ProviderPreferencesBaseDialog < SimpleDelegator
+    class ProviderPreferencesBaseDialog
       def initialize(title:, parent:, flags:, buttons:)
-        dialog = Gtk::Dialog.new(title: title, parent: parent, flags: flags,
+        @dialog = Gtk::Dialog.new(title: title, parent: parent, flags: flags,
                                  buttons: buttons)
-        super(dialog)
 
-        self.resizable = false
-        child.border_width = 12
+        @dialog.resizable = false
+        @dialog.child.border_width = 12
 
         @controls = []
       end
+
+      private
+
+      attr_reader :dialog
 
       def fill_table(table, provider)
         i = table.n_rows

--- a/lib/alexandria/ui/provider_preferences_dialog.rb
+++ b/lib/alexandria/ui/provider_preferences_dialog.rb
@@ -20,9 +20,9 @@ module Alexandria
 
         table = Gtk::Table.new(0, 0)
         fill_table(table, provider)
-        child.pack_start(table)
+        dialog.child.pack_start(table)
 
-        signal_connect("destroy") { sync_variables }
+        dialog.signal_connect("destroy") { sync_variables }
       end
 
       def acquire

--- a/lib/alexandria/ui/provider_preferences_dialog.rb
+++ b/lib/alexandria/ui/provider_preferences_dialog.rb
@@ -26,9 +26,9 @@ module Alexandria
       end
 
       def acquire
-        show_all
-        run
-        destroy
+        dialog.show_all
+        dialog.run
+        dialog.destroy
       end
     end
   end

--- a/lib/alexandria/ui/really_delete_dialog.rb
+++ b/lib/alexandria/ui/really_delete_dialog.rb
@@ -40,7 +40,7 @@ module Alexandria
                [Gtk::Stock::DELETE, Gtk::ResponseType::OK]],
               description)
 
-        self.default_response = Gtk::ResponseType::CANCEL
+        dialog.default_response = Gtk::ResponseType::CANCEL
       end
 
       def ok?

--- a/lib/alexandria/ui/skip_entry_dialog.rb
+++ b/lib/alexandria/ui/skip_entry_dialog.rb
@@ -20,7 +20,7 @@ module Alexandria
                [_("_Continue"), Gtk::ResponseType::OK]],
               message)
         log.debug { "Opened SkipEntryDialog #{inspect}" }
-        self.default_response = Gtk::ResponseType::CANCEL
+        dialog.default_response = Gtk::ResponseType::CANCEL
       end
 
       def continue?

--- a/lib/alexandria/ui/smart_library_properties_dialog.rb
+++ b/lib/alexandria/ui/smart_library_properties_dialog.rb
@@ -15,20 +15,20 @@ module Alexandria
 
         @smart_library = smart_library
 
-        @dialog.add_buttons([Gtk::Stock::CANCEL, :cancel],
-                    [Gtk::Stock::SAVE, :ok])
+        dialog.add_buttons([Gtk::Stock::CANCEL, :cancel],
+                           [Gtk::Stock::SAVE, :ok])
 
-        @dialog.title = _("Properties for '%s'") % @smart_library.name
+        dialog.title = _("Properties for '%s'") % @smart_library.name
         # FIXME: Should accept just :cancel
-        @dialog.default_response = Gtk::ResponseType::CANCEL
+        dialog.default_response = Gtk::ResponseType::CANCEL
         @smart_library.rules.each { |x| insert_new_rule(x) }
         update_rules_header_box(@smart_library.predicate_operator_rule)
       end
 
       def acquire
-        show_all
+        dialog.show_all
 
-        while (response = run) != Gtk::ResponseType::CANCEL
+        while (response = dialog.run) != Gtk::ResponseType::CANCEL
           if response == Gtk::ResponseType::HELP
             handle_help_response
           elsif response == Gtk::ResponseType::OK
@@ -36,8 +36,10 @@ module Alexandria
           end
         end
 
-        destroy
+        dialog.destroy
       end
+
+      private
 
       def handle_ok_response
         user_confirms_possible_weirdnesses_before_saving? or return

--- a/lib/alexandria/ui/smart_library_properties_dialog.rb
+++ b/lib/alexandria/ui/smart_library_properties_dialog.rb
@@ -1,21 +1,8 @@
 # frozen_string_literal: true
 
-# Copyright (C) 2004-2006 Laurent Sansonetti
+# This file is part of Alexandria.
 #
-# Alexandria is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-#
-# Alexandria is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public
-# License along with Alexandria; see the file COPYING.  If not,
-# write to the Free Software Foundation, Inc., 51 Franklin Street,
-# Fifth Floor, Boston, MA 02110-1301 USA.
+# See the file README.md for authorship and licensing information.
 
 module Alexandria
   module UI

--- a/lib/alexandria/ui/smart_library_properties_dialog.rb
+++ b/lib/alexandria/ui/smart_library_properties_dialog.rb
@@ -15,12 +15,12 @@ module Alexandria
 
         @smart_library = smart_library
 
-        add_buttons([Gtk::Stock::CANCEL, :cancel],
+        @dialog.add_buttons([Gtk::Stock::CANCEL, :cancel],
                     [Gtk::Stock::SAVE, :ok])
 
-        self.title = _("Properties for '%s'") % @smart_library.name
+        @dialog.title = _("Properties for '%s'") % @smart_library.name
         # FIXME: Should accept just :cancel
-        self.default_response = Gtk::ResponseType::CANCEL
+        @dialog.default_response = Gtk::ResponseType::CANCEL
         @smart_library.rules.each { |x| insert_new_rule(x) }
         update_rules_header_box(@smart_library.predicate_operator_rule)
       end

--- a/lib/alexandria/ui/smart_library_properties_dialog_base.rb
+++ b/lib/alexandria/ui/smart_library_properties_dialog_base.rb
@@ -68,10 +68,10 @@ module Alexandria
       # TODO: Move logic to SmartLibraryRuleBox
       def apply_smart_rule_for_rule_box(rule_box, operand, operation)
         idx = @rules_box.children.index(rule_box)
-        @smart_library_rules[idx] ||= SmartLibrary::Rule.new(operand,
+        smart_library_rules[idx] ||= SmartLibrary::Rule.new(operand,
                                                              operation.first,
                                                              nil)
-        new_rule = @smart_library_rules[idx]
+        new_rule = smart_library_rules[idx]
         new_rule.operand = operand
         new_rule.operation = operation.first
         new_rule.value = nil
@@ -79,10 +79,7 @@ module Alexandria
 
       protected
 
-      def smart_library_rules
-        fill_smart_library_rules_values
-        @smart_library_rules
-      end
+      attr_reader :smart_library_rules
 
       def has_weirdnesses?
         fill_smart_library_rules_values
@@ -188,7 +185,7 @@ module Alexandria
         idx = @rules_box.children.index(rule_box)
         raise if idx.nil?
 
-        @smart_library_rules.delete_at(idx)
+        smart_library_rules.delete_at(idx)
         @rules_box.remove(rule_box)
         sensitize_remove_rule_buttons
         update_rules_header_box
@@ -221,7 +218,7 @@ module Alexandria
               value = Time.now
             end
           end
-          @smart_library_rules[i].value = value
+          smart_library_rules[i].value = value
         end
       end
 

--- a/lib/alexandria/ui/smart_library_properties_dialog_base.rb
+++ b/lib/alexandria/ui/smart_library_properties_dialog_base.rb
@@ -14,6 +14,7 @@ module Alexandria
       GetText.bindtextdomain(Alexandria::TEXTDOMAIN, charset: "UTF-8")
 
       attr_reader :predicate_operator_rule
+      attr_reader :dialog
 
       def initialize(parent)
         @dialog = Gtk::Dialog.new(title: "",

--- a/lib/alexandria/ui/smart_library_properties_dialog_base.rb
+++ b/lib/alexandria/ui/smart_library_properties_dialog_base.rb
@@ -8,7 +8,7 @@ require "alexandria/ui/smart_library_rule_box"
 
 module Alexandria
   module UI
-    class SmartLibraryPropertiesDialogBase < SimpleDelegator
+    class SmartLibraryPropertiesDialogBase
       include Logging
       include GetText
       GetText.bindtextdomain(Alexandria::TEXTDOMAIN, charset: "UTF-8")
@@ -20,18 +20,17 @@ module Alexandria
                                   parent: parent,
                                   flags: :modal,
                                   buttons: [[Gtk::Stock::HELP, :help]])
-        super(@dialog)
 
-        self.window_position = :center
-        self.resizable = true
-        self.border_width = 4
-        child.border_width = 12
+        @dialog.window_position = :center
+        @dialog.resizable = true
+        @dialog.border_width = 4
+        @dialog.child.border_width = 12
 
         main_box = Gtk::Box.new :vertical
         main_box.border_width = 4
         main_box.spacing = 8
 
-        child << main_box
+        @dialog.child << main_box
 
         @smart_library_rules = []
 

--- a/spec/alexandria/library_spec.rb
+++ b/spec/alexandria/library_spec.rb
@@ -102,7 +102,7 @@ describe Alexandria::Library do
   describe ".import_as_isbn_list" do
     before do
       libraries = Alexandria::LibraryCollection.instance
-      library = Alexandria::Library.new("Test Library")
+      library = described_class.new("Test Library")
       libraries.add_library(library)
 
       allow(Alexandria::BookProviders)
@@ -115,8 +115,8 @@ describe Alexandria::Library do
 
     it "imports books with correct isbn and search result" do
       library, bad_isbns, failed_lookup_isbns =
-        Alexandria::Library.import_as_isbn_list("Test Library", "spec/data/isbns.txt",
-                                                proc {}, proc {})
+        described_class.import_as_isbn_list("Test Library", "spec/data/isbns.txt",
+                                            proc {}, proc {})
 
       aggregate_failures do
         expect(library.to_a).to eq [an_artist_of_the_floating_world]

--- a/spec/alexandria/ui/import_dialog_spec.rb
+++ b/spec/alexandria/ui/import_dialog_spec.rb
@@ -7,8 +7,18 @@
 require File.dirname(__FILE__) + "/../../spec_helper"
 
 describe Alexandria::UI::ImportDialog do
-  it "works" do
-    parent = Gtk::Window.new :toplevel
+  let(:parent) { Gtk::Window.new :toplevel }
+
+  it "can be instantiated" do
     described_class.new parent
+  end
+
+  describe "#acquire" do
+    it "works when response is cancel" do
+      import_dialog = described_class.new parent
+      chooser = import_dialog.dialog
+      allow(chooser).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
+      import_dialog.acquire
+    end
   end
 end

--- a/spec/alexandria/ui/import_dialog_spec.rb
+++ b/spec/alexandria/ui/import_dialog_spec.rb
@@ -14,11 +14,28 @@ describe Alexandria::UI::ImportDialog do
   end
 
   describe "#acquire" do
+    let(:import_dialog) { described_class.new parent }
+    let(:chooser) { import_dialog.dialog }
+
+    before do
+      allow(chooser).to receive(:filename).and_return("spec/data/isbns.txt")
+      allow(Alexandria::BookProviders).to receive(:isbn_search)
+        .and_raise Alexandria::BookProviders::SearchEmptyError
+      allow(Alexandria::BookProviders).to receive(:isbn_search).with("0595371086")
+        .and_return(an_artist_of_the_floating_world)
+    end
+
     it "works when response is cancel" do
-      import_dialog = described_class.new parent
-      chooser = import_dialog.dialog
       allow(chooser).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
-      import_dialog.acquire
+      import_dialog.acquire {}
+    end
+
+    it "works when response is OK" do
+      allow(chooser).to receive(:run).and_return(Gtk::ResponseType::OK)
+
+      result = nil
+      import_dialog.acquire { |*args| result = args }
+      expect(result.first.to_a).to eq [an_artist_of_the_floating_world]
     end
   end
 end

--- a/spec/alexandria/ui/new_provider_dialog_spec.rb
+++ b/spec/alexandria/ui/new_provider_dialog_spec.rb
@@ -7,8 +7,24 @@
 require File.dirname(__FILE__) + "/../../spec_helper"
 
 describe Alexandria::UI::NewProviderDialog do
-  it "works" do
-    parent = Gtk::Window.new :toplevel
+  let(:parent) { Gtk::Window.new :toplevel }
+
+  it "can be instantiated" do
     described_class.new parent
+  end
+
+  describe "#acquire" do
+    let(:provider_dialog) { described_class.new parent }
+    let(:gtk_dialog) { provider_dialog.dialog }
+
+    it "works when response is cancel" do
+      allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
+      provider_dialog.acquire
+    end
+
+    it "works when response is accept" do
+      allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::ACCEPT)
+      provider_dialog.acquire
+    end
   end
 end

--- a/spec/alexandria/ui/new_smart_library_dialog_spec.rb
+++ b/spec/alexandria/ui/new_smart_library_dialog_spec.rb
@@ -13,18 +13,26 @@ describe Alexandria::UI::NewSmartLibraryDialog do
     described_class.new parent
   end
 
-  describe "#handle_ok_response" do
-    it "returns a smart library" do
-      dialog = described_class.new parent
-      result = dialog.handle_ok_response
+  describe "#acquire" do
+    let(:properties_dialog) { described_class.new parent }
+    let(:gtk_dialog) { properties_dialog.dialog }
 
-      expect(result).to be_a Alexandria::SmartLibrary
+    it "works when response is cancel" do
+      allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
+      properties_dialog.acquire
     end
 
-    it "returns a result that can be saved" do
-      dialog = described_class.new parent
-      result = dialog.handle_ok_response
+    it "returns a smart library that can be saved when response is ok" do
+      allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::OK)
 
+      # Make sure entered rule is valid
+      rules_box = properties_dialog.instance_variable_get("@rules_box")
+      entry = rules_box.children.first.children[2]
+      entry.text = "foo"
+
+      result = properties_dialog.acquire
+
+      expect(result).to be_a Alexandria::SmartLibrary
       expect { result.save }.not_to raise_error
     end
   end

--- a/spec/alexandria/ui/provider_preferences_dialog_spec.rb
+++ b/spec/alexandria/ui/provider_preferences_dialog_spec.rb
@@ -7,13 +7,29 @@
 require File.dirname(__FILE__) + "/../../spec_helper"
 
 describe Alexandria::UI::ProviderPreferencesDialog do
-  it "works" do
-    parent = Gtk::Window.new :toplevel
+  let(:parent) { Gtk::Window.new :toplevel }
+
+  it "can be instantiated" do
     preferences = instance_double(Alexandria::BookProviders::Preferences,
                                   length: 0, read: [])
     provider = instance_double(Alexandria::BookProviders::GenericProvider,
                                fullname: "FooProvider",
                                prefs: preferences)
     described_class.new parent, provider
+  end
+
+  describe "#acquire" do
+    it "works" do
+      preferences = instance_double(Alexandria::BookProviders::Preferences,
+                                    length: 0, read: [])
+      provider = instance_double(Alexandria::BookProviders::GenericProvider,
+                                 fullname: "FooProvider",
+                                 prefs: preferences)
+      preferences_dialog = described_class.new parent, provider
+      gtk_dialog = preferences_dialog.dialog
+      allow(gtk_dialog).to receive(:run)
+
+      preferences_dialog.acquire
+    end
   end
 end

--- a/spec/alexandria/ui/smart_library_properties_dialog_spec.rb
+++ b/spec/alexandria/ui/smart_library_properties_dialog_spec.rb
@@ -15,12 +15,18 @@ describe Alexandria::UI::SmartLibraryPropertiesDialog do
     described_class.new parent, smart_library
   end
 
-  describe "#handle_ok_response" do
-    it "returns true" do
-      dialog = described_class.new parent, smart_library
-      result = dialog.handle_ok_response
+  describe "#acquire" do
+    let(:properties_dialog) { described_class.new parent, smart_library }
+    let(:gtk_dialog) { properties_dialog.dialog }
 
-      expect(result).to be_truthy
+    it "works when response is cancel" do
+      allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
+      properties_dialog.acquire
+    end
+
+    it "works when response is ok" do
+      allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::OK)
+      properties_dialog.acquire
     end
   end
 end


### PR DESCRIPTION
Using SimpleDelegator makes debugging with Pry super-hard. It was used in Alexandria as a kind of inheritance mechanism instead of a decorator. Instead, use regular composition with explicit delegation where needed.