### PR TITLE
Improve spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,10 @@
 #
 # See the file README.md for authorship and licensing information.
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "/../lib"))
-
+require "rspec"
 require "alexandria"
 
-LIBDIR = File.expand_path(File.join(File.dirname(__FILE__), "/data/libraries"))
+LIBDIR = File.expand_path("data/libraries", __dir__)
 TESTDIR = File.join(LIBDIR, "test")
 
 def an_artist_of_the_floating_world


### PR DESCRIPTION
- Depend on Bundler to set the load path correctly; specs should be run inside `bundle exec`
- Require `rspec` explicitly since we refer to RSpec in this file
- Simplify code to set `LIBDIR` by using modern `__dir__` instead of `__FILE__`, which is available in all supported Ruby versions