### PR TITLE
Clean up some translatable messages

### DIFF
--- a/lib/alexandria/book_providers/amazon_ecs_util.rb
+++ b/lib/alexandria/book_providers/amazon_ecs_util.rb
@@ -56,8 +56,6 @@ module Alexandria
       end
 
       def self.configure(&_proc)
-        raise ArgumentError, _("Block is required.") unless block_given?
-
         yield @@options
       end
 

--- a/lib/alexandria/ui/keep_bad_isbn_dialog.rb
+++ b/lib/alexandria/ui/keep_bad_isbn_dialog.rb
@@ -16,7 +16,7 @@ module Alexandria
         title = _("Invalid ISBN '%s'") % book.isbn
         message =
           _("The book titled '%s' has an invalid ISBN, but still " \
-            "exists in the providers libraries.  Do you want to " \
+            "exists in the providers libraries. Do you want to " \
             "keep the book but change the ISBN or cancel the addition?") % book.title
         super(parent, title,
               Gtk::Stock::DIALOG_QUESTION,

--- a/lib/alexandria/ui/sidepane_manager.rb
+++ b/lib/alexandria/ui/sidepane_manager.rb
@@ -53,7 +53,7 @@ module Alexandria
             chars = match[1].gsub(/&/, "&amp;")
             ErrorDialog.new(@main_app, _("Invalid library name '%s'") % new_text,
                             _("The name provided contains the " \
-                              "disallowed character <b>%s</b> ") % chars).display
+                              "disallowed character <b>%s</b>") % chars).display
           else
             ErrorDialog.new(@main_app, _("Invalid library name"),
                             _("The name provided contains " \

--- a/share/alexandria/glade/main_app__builder.glade
+++ b/share/alexandria/glade/main_app__builder.glade
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="main_app">
     <property name="can_focus">False</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
@@ -135,14 +138,7 @@
                   </object>
                 </child>
                 <child type="tab">
-                  <object class="GtkLabel" id="label2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">label</property>
-                  </object>
-                  <packing>
-                    <property name="tab_fill">False</property>
-                  </packing>
+                  <placeholder/>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow4">
@@ -165,15 +161,7 @@
                   </packing>
                 </child>
                 <child type="tab">
-                  <object class="GtkLabel" id="label3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">label</property>
-                  </object>
-                  <packing>
-                    <property name="position">1</property>
-                    <property name="tab_fill">False</property>
-                  </packing>
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -227,9 +215,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>


### PR DESCRIPTION
This cleans up some messages so translations will require a bit less work and
are cleaner.

- Remove useless check for block

  The yield will already raise an exception if no block is given, so there's
  no point in first checking that ourselves.

- Remove trailing space from message

- Remove unused labels from main app UI

- Remove extra space from message text