### PR TITLE
Modernize translation infrastructure

### DIFF
--- a/alexandria.desktop.in
+++ b/alexandria.desktop.in
@@ -1,9 +1,9 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-_Name=Alexandria Book Collection Manager
-_GenericName=Book Collection Manager
-_Comment=Manage your book collection
+Name=Alexandria Book Collection Manager
+GenericName=Book Collection Manager
+Comment=Manage your book collection
 Exec=/usr/bin/alexandria
 Terminal=false
 Categories=GNOME;GTK;Office;Database;

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,0 +1,22 @@
+# Set of available languages.
+cs
+cy
+de
+el
+es
+fr
+ga
+gl
+it
+ja
+mk
+nb
+nl
+pl
+pt
+pt_BR
+ru
+sk
+sv
+uk
+zh_TW

--- a/po/Makefile
+++ b/po/Makefile
@@ -3,23 +3,20 @@ POT=./alexandria.pot
 
 RUBY=../exe/alexandria $(shell find ../lib -name '*.rb' -and -not -path '*macui*')
 
-GLADE=$(shell find ../share/alexandria/glade -name '*.glade')
+DESKTOP=../alexandria.desktop
 
-HEADERS=$(shell find .. -name '*.h')
+GLADE=$(shell find ../share/alexandria/glade -name '*.glade')
 
 PO=$(wildcard *.po)
 
-$(POT): $(RUBY) $(GLADE) ../alexandria.desktop.in.h $(HEADERS)
+$(POT): $(RUBY) $(GLADE) $(DESKTOP)
 	rm -f $(POT)
 	@echo Updating PO template from Ruby files
 	@rxgettext --output=$(POT) $(RUBY)
 	@echo Updating PO template from Glade files
 	@xgettext --output=$(POT) --join-existing $(GLADE)
-	@echo Updating PO template from header files
-	@xgettext --output=$(POT) --join-existing --extract-all $(HEADERS)
-
-../alexandria.desktop.in.h: ../alexandria.desktop.in
-	intltool-extract --type=gettext/ini ../alexandria.desktop.in
+	@echo Updating PO template from desktop file
+	@xgettext --output=$(POT) --join-existing $(DESKTOP)
 
 $(PO): $(POT)
 	msgmerge -U $@ $(POT)

--- a/po/nl.po
+++ b/po/nl.po
@@ -1354,17 +1354,21 @@ msgstr "_Sinds:"
 msgid "Loaning"
 msgstr "Uitlenen"
 
-#: ../alexandria.desktop.in.h:1
+#: ../alexandria.desktop:5
 msgid "Alexandria Book Collection Manager"
 msgstr "Alexandria Boekcollectiebeheerder"
 
-#: ../alexandria.desktop.in.h:2
+#: ../alexandria.desktop:6
 msgid "Book Collection Manager"
 msgstr "Boekcollectiebeheerder"
 
-#: ../alexandria.desktop.in.h:3
+#: ../alexandria.desktop:7
 msgid "Manage your book collection"
 msgstr "Beheer uw boekcollectie"
+
+#: ../alexandria.desktop:11
+msgid "alexandria"
+msgstr ""
 
 #~ msgid "Locale"
 #~ msgstr "Taal"

--- a/util/rake/gettextgenerate.rb
+++ b/util/rake/gettextgenerate.rb
@@ -69,12 +69,8 @@ class GettextGenerateTask < Rake::TaskLib
   def generate_desktop(infile, outfile)
     @generated_files << outfile
     file outfile => [infile, *po_files] do |_f|
-      begin
-        `intltool-merge --version`
-      rescue Errno::ENOENT
-        raise "Need to install intltool"
-      end
-      system("intltool-merge -d #{@po_dir} #{infile} #{outfile}")
+      result = system("msgfmt --desktop --template #{infile} -d #{@po_dir} -o #{outfile}")
+      raise "msgfmt failed for #{infile}" unless result
     end
   end
 


### PR DESCRIPTION
- Use xgettext to extract translations from desktop file directly, avoiding the need to use intltool
- Make git ignore translation build artifacts

Fixes #43 