### PR TITLE
Fix RuboCop offenses in specs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -76,9 +76,6 @@ RSpec/FilePath:
     - 'spec/alexandria/ui/iconview_spec.rb'
     - 'spec/alexandria/ui/sound_spec.rb'
 
-RSpec/MultipleExpectations:
-  Max: 7
-
 # Cop supports --auto-correct.
 # Configuration parameters: Strict, EnforcedStyle, AllowedExplicitMatchers.
 # SupportedStyles: inflected, explicit

--- a/spec/alexandria/book_providers/bl_provider_spec.rb
+++ b/spec/alexandria/book_providers/bl_provider_spec.rb
@@ -8,6 +8,6 @@ require "spec_helper"
 
 describe Alexandria::BookProviders::BLProvider do
   it "works" do
-    assert_correct_search_result(described_class, "9781853260803")
+    expect(described_class).to have_correct_search_result_for "9781853260803"
   end
 end

--- a/spec/alexandria/book_providers/loc_provider_spec.rb
+++ b/spec/alexandria/book_providers/loc_provider_spec.rb
@@ -8,10 +8,10 @@ require "spec_helper"
 
 describe Alexandria::BookProviders::LOCProvider do
   it "works for a book with ASCII title" do
-    assert_correct_search_result(described_class, "9780805335583")
+    expect(described_class).to have_correct_search_result_for "9780805335583"
   end
 
   it "works for a book with a title with non-ASCII letters" do
-    assert_correct_search_result(described_class, "9782070379248")
+    expect(described_class).to have_correct_search_result_for "9782070379248"
   end
 end

--- a/spec/alexandria/book_providers/sbn_provider_spec.rb
+++ b/spec/alexandria/book_providers/sbn_provider_spec.rb
@@ -8,6 +8,6 @@ require "spec_helper"
 
 describe Alexandria::BookProviders::SBNProvider do
   it "works" do
-    assert_correct_search_result(described_class, "9788835926436")
+    expect(described_class).to have_correct_search_result_for "9788835926436"
   end
 end

--- a/spec/alexandria/book_providers/thalia_provider_spec.rb
+++ b/spec/alexandria/book_providers/thalia_provider_spec.rb
@@ -114,6 +114,6 @@ RSpec.describe Alexandria::BookProviders::ThaliaProvider do
     stub_request(:get, "https://www.thalia.de/shop/home/artikeldetails/ID134292338.html")
       .to_return(status: 200, body: normal_people_details, headers: {})
 
-    assert_correct_search_result(described_class, "9780571334650")
+    expect(described_class).to have_correct_search_result_for "9780571334650"
   end
 end

--- a/spec/alexandria/book_spec.rb
+++ b/spec/alexandria/book_spec.rb
@@ -28,10 +28,12 @@ describe Alexandria::Book do
   it "establishes equality only with books with the same identity" do
     book = an_artist_of_the_floating_world
     same_book = an_artist_of_the_floating_world
-    expect(same_book).to eq book
     different_book = an_artist_of_the_floating_world
     different_book.isbn = "9780571147999"
-    expect(different_book).not_to eq book
+    aggregate_failures do
+      expect(same_book).to eq book
+      expect(different_book).not_to eq book
+    end
   end
 
   describe "#rating" do

--- a/spec/alexandria/book_spec.rb
+++ b/spec/alexandria/book_spec.rb
@@ -22,7 +22,7 @@ require "spec_helper"
 
 describe Alexandria::Book do
   it "is a thing" do
-    an_artist_of_the_floating_world
+    expect(an_artist_of_the_floating_world).to be_a described_class
   end
 
   it "establishes equality only with books with the same identity" do

--- a/spec/alexandria/library_spec.rb
+++ b/spec/alexandria/library_spec.rb
@@ -12,8 +12,10 @@ describe Alexandria::Library do
   describe "::EXT" do
     it "has symbolic references to file extensions" do
       extensions = Alexandria::Library::EXT
-      expect(extensions[:book]).not_to be_nil
-      expect(extensions[:cover]).not_to be_nil
+      aggregate_failures do
+        expect(extensions[:book]).not_to be_nil
+        expect(extensions[:cover]).not_to be_nil
+      end
     end
   end
 
@@ -27,23 +29,26 @@ describe Alexandria::Library do
 
   describe "#valid_ean?" do
     it "returns a true value for valid EANs" do
-      expect(described_class.valid_ean?("9780345431929")).to be_truthy
-      expect(described_class.valid_ean?("978034543192912345")).to be_truthy
+      aggregate_failures do
+        expect(described_class.valid_ean?("9780345431929")).to be_truthy
+        expect(described_class.valid_ean?("978034543192912345")).to be_truthy
 
-      # Regression test: this EAN has a checksum of 10, which should be
-      # treated like a checksum of 0.
-      expect(described_class.valid_ean?("9784047041790")).to be_truthy
+        # Regression test: this EAN has a checksum of 10, which should be
+        # treated like a checksum of 0.
+        expect(described_class.valid_ean?("9784047041790")).to be_truthy
+      end
     end
 
     it "returns a false value for invalid EANs" do
-      expect(described_class.valid_ean?("780345431929")).to be_falsey
-      expect(described_class.valid_ean?("97803454319290")).to be_falsey
-      expect(described_class.valid_ean?("97803454319291234")).to be_falsey
-      expect(described_class.valid_ean?("9780345431929123456")).to be_falsey
-      expect(described_class.valid_ean?("9780345431928")).to be_falsey
-      expect(described_class.valid_ean?("9780345431929A")).to be_falsey
+      invalid_eans = ["780345431929", "97803454319290", "97803454319291234",
+                      "9780345431929123456", "9780345431928", "9780345431929A",
+                      "9784047041791"]
 
-      expect(described_class.valid_ean?("9784047041791")).to be_falsey
+      aggregate_failures do
+        invalid_eans.each do |ean|
+          expect(described_class.valid_ean?(ean)).to be_falsey
+        end
+      end
     end
   end
 
@@ -53,21 +58,25 @@ describe Alexandria::Library do
     end
 
     it "returns a false value for invalid UPCs" do
-      expect(described_class.valid_upc?("978034543193123567")).to be_falsey
-      expect(described_class.valid_upc?("9780345431931235")).to be_falsey
+      aggregate_failures do
+        expect(described_class.valid_upc?("978034543193123567")).to be_falsey
+        expect(described_class.valid_upc?("9780345431931235")).to be_falsey
 
-      expect(described_class.valid_upc?("97803454319412356")).to be_falsey
-      expect(described_class.valid_upc?("97803454319212356")).to be_falsey
+        expect(described_class.valid_upc?("97803454319412356")).to be_falsey
+        expect(described_class.valid_upc?("97803454319212356")).to be_falsey
+      end
     end
   end
 
   describe "#canonicalise_isbn" do
     it "returns the correct value for several examples" do
-      expect(described_class.canonicalise_isbn("014143984X")).to eq "014143984X"
-      expect(described_class.canonicalise_isbn("0-345-43192-8")).to eq "0345431928"
-      expect(described_class.canonicalise_isbn("3522105907")).to eq "3522105907"
-      # EAN number
-      expect(described_class.canonicalise_isbn("9780345431929")).to eq "0345431928"
+      aggregate_failures do
+        expect(described_class.canonicalise_isbn("014143984X")).to eq "014143984X"
+        expect(described_class.canonicalise_isbn("0-345-43192-8")).to eq "0345431928"
+        expect(described_class.canonicalise_isbn("3522105907")).to eq "3522105907"
+        # EAN number
+        expect(described_class.canonicalise_isbn("9780345431929")).to eq "0345431928"
+      end
     end
   end
 
@@ -136,21 +145,27 @@ describe Alexandria::Library do
     end
 
     it "can be loaded" do
-      expect(libs.size).to eq(1)
-      expect(my_library.size).to eq(3)
+      aggregate_failures do
+        expect(libs.size).to eq(1)
+        expect(my_library.size).to eq(3)
+      end
     end
 
-    it "imports cleanly from version 0.6.1 data format" do
-      # Malory
+    it "imports Malory book cleanly from version 0.6.1 data format" do
       malory_book = my_library.find { |b| b.isbn == "9780192812179" }
-      expect(malory_book.publisher).to eq("Oxford University Press")
-      expect(malory_book.authors.include?("Vinaver")).to be_truthy
-      expect(malory_book.version).to eq(Alexandria::DATA_VERSION)
+      aggregate_failures do
+        expect(malory_book.publisher).to eq("Oxford University Press")
+        expect(malory_book.authors.include?("Vinaver")).to be_truthy
+        expect(malory_book.version).to eq(Alexandria::DATA_VERSION)
+      end
+    end
 
-      # Guide to LaTeX
+    it "imports Guide to LaTeX cleanly from version 0.6.1 data format" do
       latex_book = my_library.find { |b| b.title.include? "Latex" }
-      expect(latex_book.isbn).to eq("9780201398250")
-      expect(latex_book.publisher).to eq("Addison Wesley")
+      aggregate_failures do
+        expect(latex_book.isbn).to eq("9780201398250")
+        expect(latex_book.publisher).to eq("Addison Wesley")
+      end
     end
   end
 
@@ -168,16 +183,20 @@ describe Alexandria::Library do
     end
 
     it "can be loaded" do
-      expect(libs.size).to eq(1)
-      expect(my_library.size).to eq(2)
+      aggregate_failures do
+        expect(libs.size).to eq(1)
+        expect(my_library.size).to eq(2)
+      end
     end
 
     it "loads a book with ISBN" do
       # Guide to LaTeX
       latex_book = my_library.find { |b| b.title.include? "Latex" }
-      expect(latex_book.isbn).to eq("9780201398250")
-      expect(latex_book.publisher).to eq("Addison Wesley")
-      expect(latex_book.version).to eq(Alexandria::DATA_VERSION)
+      aggregate_failures do
+        expect(latex_book.isbn).to eq("9780201398250")
+        expect(latex_book.publisher).to eq("Addison Wesley")
+        expect(latex_book.version).to eq(Alexandria::DATA_VERSION)
+      end
     end
 
     it "loads a book without ISBN" do
@@ -189,13 +208,8 @@ describe Alexandria::Library do
     it "saves loaded books properly" do
       my_library.each { |book| my_library.save(book, true) }
       my_library_reloaded = loader.load_all_libraries[0]
-      expect(my_library_reloaded.size).to eq(2)
 
-      latex_book = my_library_reloaded.find { |b| b.title.include? "Latex" }
-      expect(latex_book.publisher).to eq("Addison Wesley")
-
-      lex_and_yacc_book = my_library_reloaded.find { |b| b.title.include? "Lex" }
-      expect(lex_and_yacc_book.publisher).to eq("O'Reilley")
+      expect(my_library_reloaded.map(&:publisher)).to eq ["O'Reilley", "Addison Wesley"]
     end
   end
 

--- a/spec/alexandria/scanners/cue_cat_spec.rb
+++ b/spec/alexandria/scanners/cue_cat_spec.rb
@@ -42,6 +42,7 @@ describe Alexandria::Scanners::CueCat do
     # TODO are we supposed to keep the +5 bit?
   end
 
+  # rubocop:disable RSpec/NoExpectationExample
   it "decodes ISSN barcodes" do
     skip "Test scan ISSN"
   end
@@ -49,4 +50,5 @@ describe Alexandria::Scanners::CueCat do
   it "decodes UPC barcodes" do
     skip "Test scan UPC"
   end
+  # rubocop:enable RSpec/NoExpectationExample
 end

--- a/spec/alexandria/scanners/cue_cat_spec.rb
+++ b/spec/alexandria/scanners/cue_cat_spec.rb
@@ -27,10 +27,17 @@ describe Alexandria::Scanners::CueCat do
     expect(cuecat.name).to match(/CueCat/i)
   end
 
-  it "detects a complete scan only" do
-    partials.each { |scan| expect(cuecat.match?(scan)).not_to be_truthy }
-    expect(cuecat.match?(scans[:isbn])).to be_truthy
-    expect(cuecat.match?(scans[:ib5])).to be_truthy
+  it "refuses to detect incomplete scans" do
+    aggregate_failures do
+      partials.each { |scan| expect(cuecat.match?(scan)).not_to be_truthy }
+    end
+  end
+
+  it "detects complete scans" do
+    aggregate_failures do
+      expect(cuecat.match?(scans[:isbn])).to be_truthy
+      expect(cuecat.match?(scans[:ib5])).to be_truthy
+    end
   end
 
   it "decodes ISBN barcodes" do

--- a/spec/alexandria/smart_library_spec.rb
+++ b/spec/alexandria/smart_library_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe Alexandria::SmartLibrary do
     it "normalizes the encoding" do
       bad_name = (+"Prêts").force_encoding("ascii")
       lib = described_class.new(bad_name, [], :all)
-      expect(lib.name.encoding.name).to eq "UTF-8"
-      expect(bad_name.encoding.name).to eq "US-ASCII"
+      aggregate_failures do
+        expect(lib.name.encoding.name).to eq "UTF-8"
+        expect(bad_name.encoding.name).to eq "US-ASCII"
+      end
     end
   end
 

--- a/spec/alexandria/smart_library_spec.rb
+++ b/spec/alexandria/smart_library_spec.rb
@@ -25,15 +25,15 @@ RSpec.describe Alexandria::SmartLibrary do
     let(:lib) { described_class.new("Hello", [], :all) }
 
     it "works when given no parameters" do
-      lib.update
+      expect { lib.update }.not_to raise_error
     end
 
     it "works when given a LibraryCollection" do
-      lib.update Alexandria::LibraryCollection.instance
+      expect { lib.update Alexandria::LibraryCollection.instance }.not_to raise_error
     end
 
     it "works when given a Library" do
-      lib.update Alexandria::Library.new("Hi")
+      expect { lib.update Alexandria::Library.new("Hi") }.not_to raise_error
     end
   end
 end

--- a/spec/alexandria/ui/about_dialog_spec.rb
+++ b/spec/alexandria/ui/about_dialog_spec.rb
@@ -9,6 +9,6 @@ require_relative "../../spec_helper"
 describe Alexandria::UI::AboutDialog do
   it "works" do
     parent = Gtk::Window.new :toplevel
-    described_class.new parent
+    expect { described_class.new parent }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/acquire_dialog_spec.rb
+++ b/spec/alexandria/ui/acquire_dialog_spec.rb
@@ -9,6 +9,6 @@ require_relative "../../spec_helper"
 describe Alexandria::UI::AcquireDialog do
   it "works" do
     parent = Gtk::Window.new :toplevel
-    described_class.new parent
+    expect { described_class.new parent }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/alert_dialog_spec.rb
+++ b/spec/alexandria/ui/alert_dialog_spec.rb
@@ -9,8 +9,10 @@ require_relative "../../spec_helper"
 describe Alexandria::UI::AlertDialog do
   it "works" do
     parent = Gtk::Window.new :toplevel
-    described_class.new(parent, "Hello",
-                        Gtk::Stock::DIALOG_QUESTION,
-                        [[Gtk::Stock::CANCEL, :cancel]], "Hi there")
+    expect do
+      described_class.new(parent, "Hello",
+                          Gtk::Stock::DIALOG_QUESTION,
+                          [[Gtk::Stock::CANCEL, :cancel]], "Hi there")
+    end.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/bad_isbns_dialog_spec.rb
+++ b/spec/alexandria/ui/bad_isbns_dialog_spec.rb
@@ -9,6 +9,6 @@ require_relative "../../spec_helper"
 describe Alexandria::UI::BadIsbnsDialog do
   it "works" do
     parent = Gtk::Window.new :toplevel
-    described_class.new parent, "Careful", []
+    expect { described_class.new parent, "Careful", [] }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/book_properties_dialog_spec.rb
+++ b/spec/alexandria/ui/book_properties_dialog_spec.rb
@@ -22,7 +22,7 @@ describe Alexandria::UI::BookPropertiesDialog do
   end
 
   it "works" do
-    described_class.new parent, library, book
+    expect { described_class.new parent, library, book }.not_to raise_error
   end
 
   describe "#on_change_cover" do
@@ -39,21 +39,21 @@ describe Alexandria::UI::BookPropertiesDialog do
       allow(filechooser)
         .to receive(:run).and_return(Gtk::ResponseType::ACCEPT)
 
-      dialog.on_change_cover
+      expect { dialog.on_change_cover }.not_to raise_error
     end
 
     it "works when response is reject" do
       allow(filechooser)
         .to receive(:run).and_return(Gtk::ResponseType::REJECT)
 
-      dialog.on_change_cover
+      expect { dialog.on_change_cover }.not_to raise_error
     end
 
     it "works when response is cancel" do
       allow(filechooser)
         .to receive(:run).and_return(Gtk::ResponseType::CANCEL)
 
-      dialog.on_change_cover
+      expect { dialog.on_change_cover }.not_to raise_error
     end
   end
 end

--- a/spec/alexandria/ui/confirm_erase_dialog_spec.rb
+++ b/spec/alexandria/ui/confirm_erase_dialog_spec.rb
@@ -9,6 +9,6 @@ require_relative "../../spec_helper"
 describe Alexandria::UI::ConfirmEraseDialog do
   it "works" do
     parent = Gtk::Window.new :toplevel
-    described_class.new parent, "foo-file"
+    expect { described_class.new parent, "foo-file" }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/conflict_while_copying_dialog_spec.rb
+++ b/spec/alexandria/ui/conflict_while_copying_dialog_spec.rb
@@ -11,6 +11,6 @@ describe Alexandria::UI::ConflictWhileCopyingDialog do
     parent = Gtk::Window.new :toplevel
     library = instance_double(Alexandria::Library, name: "Bar Library")
     book = instance_double(Alexandria::Book, title: "Foo Book")
-    described_class.new parent, library, book
+    expect { described_class.new parent, library, book }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/error_dialog_spec.rb
+++ b/spec/alexandria/ui/error_dialog_spec.rb
@@ -9,6 +9,6 @@ require_relative "../../spec_helper"
 describe Alexandria::UI::ErrorDialog do
   it "works" do
     parent = Gtk::Window.new :toplevel
-    described_class.new parent, "Boom", "It went boom"
+    expect { described_class.new parent, "Boom", "It went boom" }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/export_dialog_spec.rb
+++ b/spec/alexandria/ui/export_dialog_spec.rb
@@ -12,7 +12,7 @@ describe Alexandria::UI::ExportDialog do
   let(:sort_order) { Alexandria::LibrarySortOrder::Unsorted.new }
 
   it "works" do
-    described_class.new parent, library, sort_order
+    expect { described_class.new parent, library, sort_order }.not_to raise_error
   end
 
   describe "#perform" do
@@ -21,14 +21,14 @@ describe Alexandria::UI::ExportDialog do
 
     it "works when response is cancel" do
       allow(chooser).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
-      export_dialog.perform
+      expect { export_dialog.perform }.not_to raise_error
     end
 
     it "works when response is OK" do
       dir = Dir.mktmpdir
       allow(chooser).to receive(:run).and_return(Gtk::ResponseType::OK)
       allow(chooser).to receive(:filename).and_return File.join(dir, "export")
-      export_dialog.perform
+      expect { export_dialog.perform }.not_to raise_error
     ensure
       FileUtils.remove_entry dir
     end

--- a/spec/alexandria/ui/iconview_spec.rb
+++ b/spec/alexandria/ui/iconview_spec.rb
@@ -10,6 +10,6 @@ describe Alexandria::UI::IconViewManager do
   it "works" do
     iconview = instance_double(Gtk::IconView).as_null_object
     parent = instance_double(Alexandria::UI::UIManager, iconview: iconview).as_null_object
-    described_class.new iconview, parent
+    expect { described_class.new iconview, parent }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/import_dialog_spec.rb
+++ b/spec/alexandria/ui/import_dialog_spec.rb
@@ -10,12 +10,12 @@ describe Alexandria::UI::ImportDialog do
   let(:parent) { Gtk::Window.new :toplevel }
 
   it "can be instantiated" do
-    described_class.new parent
+    expect { described_class.new parent }.not_to raise_error
   end
 
   it "handles a selection change" do
     importdialog = described_class.new parent
-    importdialog.dialog.signal_emit "selection_changed"
+    expect { importdialog.dialog.signal_emit "selection_changed" }.not_to raise_error
   end
 
   describe "#acquire" do
@@ -32,7 +32,7 @@ describe Alexandria::UI::ImportDialog do
 
     it "works when response is cancel" do
       allow(chooser).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
-      import_dialog.acquire { nil }
+      expect { import_dialog.acquire { nil } }.not_to raise_error
     end
 
     it "works when response is OK" do

--- a/spec/alexandria/ui/keep_bad_isbn_dialog_spec.rb
+++ b/spec/alexandria/ui/keep_bad_isbn_dialog_spec.rb
@@ -12,6 +12,6 @@ describe Alexandria::UI::KeepBadISBNDialog do
     book = instance_double(Alexandria::Book,
                            title: "Foo Book",
                            isbn: "98765432")
-    described_class.new parent, book
+    expect { described_class.new parent, book }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/new_book_dialog_manual_spec.rb
+++ b/spec/alexandria/ui/new_book_dialog_manual_spec.rb
@@ -14,7 +14,7 @@ describe Alexandria::UI::NewBookDialogManual do
   end
 
   it "works" do
-    described_class.new parent, library
+    expect { described_class.new parent, library }.not_to raise_error
   end
 
   describe "#on_change_cover" do
@@ -31,21 +31,21 @@ describe Alexandria::UI::NewBookDialogManual do
       allow(filechooser)
         .to receive(:run).and_return(Gtk::ResponseType::ACCEPT)
 
-      dialog.on_change_cover
+      expect { dialog.on_change_cover }.not_to raise_error
     end
 
     it "works when response is reject" do
       allow(filechooser)
         .to receive(:run).and_return(Gtk::ResponseType::REJECT)
 
-      dialog.on_change_cover
+      expect { dialog.on_change_cover }.not_to raise_error
     end
 
     it "works when response is cancel" do
       allow(filechooser)
         .to receive(:run).and_return(Gtk::ResponseType::CANCEL)
 
-      dialog.on_change_cover
+      expect { dialog.on_change_cover }.not_to raise_error
     end
   end
 end

--- a/spec/alexandria/ui/new_book_dialog_spec.rb
+++ b/spec/alexandria/ui/new_book_dialog_spec.rb
@@ -11,12 +11,12 @@ describe Alexandria::UI::NewBookDialog do
   let(:model) { Gtk::ListStore.new(String, String, GdkPixbuf::Pixbuf) }
 
   it "works" do
-    described_class.new parent
+    expect { described_class.new parent }.not_to raise_error
   end
 
   it "can copy search results into result treeview" do
     results = [[an_artist_of_the_floating_world, "cover-url"]]
     dialog = described_class.new parent
-    dialog.copy_results_to_treeview_model results, model
+    expect { dialog.copy_results_to_treeview_model results, model }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/new_provider_dialog_spec.rb
+++ b/spec/alexandria/ui/new_provider_dialog_spec.rb
@@ -10,7 +10,7 @@ describe Alexandria::UI::NewProviderDialog do
   let(:parent) { Gtk::Window.new :toplevel }
 
   it "can be instantiated" do
-    described_class.new parent
+    expect { described_class.new parent }.not_to raise_error
   end
 
   describe "#acquire" do
@@ -19,12 +19,12 @@ describe Alexandria::UI::NewProviderDialog do
 
     it "works when response is cancel" do
       allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
-      provider_dialog.acquire
+      expect { provider_dialog.acquire }.not_to raise_error
     end
 
     it "works when response is accept" do
       allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::ACCEPT)
-      provider_dialog.acquire
+      expect { provider_dialog.acquire }.not_to raise_error
     end
   end
 end

--- a/spec/alexandria/ui/new_smart_library_dialog_spec.rb
+++ b/spec/alexandria/ui/new_smart_library_dialog_spec.rb
@@ -16,6 +16,8 @@ describe Alexandria::UI::NewSmartLibraryDialog do
   describe "#acquire" do
     let(:properties_dialog) { described_class.new parent }
     let(:gtk_dialog) { properties_dialog.dialog }
+    let(:rules_box) { properties_dialog.instance_variable_get(:@rules_box) }
+    let(:rule_entry) { rules_box.children.first.children[2] }
 
     it "works when response is cancel" do
       allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
@@ -26,14 +28,14 @@ describe Alexandria::UI::NewSmartLibraryDialog do
       allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::OK)
 
       # Make sure entered rule is valid
-      rules_box = properties_dialog.instance_variable_get(:@rules_box)
-      entry = rules_box.children.first.children[2]
-      entry.text = "foo"
+      rule_entry.text = "foo"
 
       result = properties_dialog.acquire
 
-      expect(result).to be_a Alexandria::SmartLibrary
-      expect { result.save }.not_to raise_error
+      aggregate_failures do
+        expect(result).to be_a Alexandria::SmartLibrary
+        expect { result.save }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/alexandria/ui/new_smart_library_dialog_spec.rb
+++ b/spec/alexandria/ui/new_smart_library_dialog_spec.rb
@@ -10,7 +10,7 @@ describe Alexandria::UI::NewSmartLibraryDialog do
   let(:parent) { Gtk::Window.new :toplevel }
 
   it "can be instantiated" do
-    described_class.new parent
+    expect { described_class.new parent }.not_to raise_error
   end
 
   describe "#acquire" do
@@ -19,7 +19,7 @@ describe Alexandria::UI::NewSmartLibraryDialog do
 
     it "works when response is cancel" do
       allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
-      properties_dialog.acquire
+      expect { properties_dialog.acquire }.not_to raise_error
     end
 
     it "returns a smart library that can be saved when response is ok" do

--- a/spec/alexandria/ui/preferences_dialog_spec.rb
+++ b/spec/alexandria/ui/preferences_dialog_spec.rb
@@ -9,6 +9,6 @@ require_relative "../../spec_helper"
 describe Alexandria::UI::PreferencesDialog do
   it "works" do
     parent = Gtk::Window.new :toplevel
-    described_class.new(parent) { nil }
+    expect { described_class.new(parent) { nil } }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/provider_preferences_dialog_spec.rb
+++ b/spec/alexandria/ui/provider_preferences_dialog_spec.rb
@@ -19,7 +19,7 @@ describe Alexandria::UI::ProviderPreferencesDialog do
   end
 
   it "can be instantiated" do
-    described_class.new parent, provider
+    expect { described_class.new parent, provider }.not_to raise_error
   end
 
   describe "#acquire" do
@@ -28,7 +28,7 @@ describe Alexandria::UI::ProviderPreferencesDialog do
       gtk_dialog = preferences_dialog.dialog
       allow(gtk_dialog).to receive(:run)
 
-      preferences_dialog.acquire
+      expect { preferences_dialog.acquire }.not_to raise_error
     end
   end
 end

--- a/spec/alexandria/ui/really_delete_dialog_spec.rb
+++ b/spec/alexandria/ui/really_delete_dialog_spec.rb
@@ -11,6 +11,6 @@ describe Alexandria::UI::ReallyDeleteDialog do
     library = instance_double(Alexandria::Library,
                               name: "Bar Library", empty?: false, size: 12)
     parent = Gtk::Window.new :toplevel
-    described_class.new parent, library
+    expect { described_class.new parent, library }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/sidepane_manager_spec.rb
+++ b/spec/alexandria/ui/sidepane_manager_spec.rb
@@ -10,6 +10,6 @@ describe Alexandria::UI::SidepaneManager do
   it "works" do
     library_listview = instance_double(Gtk::TreeView).as_null_object
     parent = instance_double(Alexandria::UI::UIManager, main_app: nil, append_library: nil)
-    described_class.new library_listview, parent
+    expect { described_class.new library_listview, parent }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/skip_entry_dialog_spec.rb
+++ b/spec/alexandria/ui/skip_entry_dialog_spec.rb
@@ -9,6 +9,6 @@ require_relative "../../spec_helper"
 describe Alexandria::UI::SkipEntryDialog do
   it "works" do
     parent = Gtk::Window.new :toplevel
-    described_class.new parent, "Foo"
+    expect { described_class.new parent, "Foo" }.not_to raise_error
   end
 end

--- a/spec/alexandria/ui/smart_library_properties_dialog_spec.rb
+++ b/spec/alexandria/ui/smart_library_properties_dialog_spec.rb
@@ -18,12 +18,12 @@ describe Alexandria::UI::SmartLibraryPropertiesDialog do
   describe "#acquire" do
     it "works when response is cancel" do
       allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
-      properties_dialog.acquire
+      expect { properties_dialog.acquire }.not_to raise_error
     end
 
     it "works when response is ok" do
       allow(gtk_dialog).to receive(:run).and_return(Gtk::ResponseType::OK)
-      properties_dialog.acquire
+      expect { properties_dialog.acquire }.not_to raise_error
     end
   end
 

--- a/spec/alexandria/ui/ui_manager_spec.rb
+++ b/spec/alexandria/ui/ui_manager_spec.rb
@@ -41,12 +41,14 @@ describe Alexandria::UI::UIManager do
       regular_library.each { |book| ui.append_book book }
       # This makes the iconview model re-appear
       ui.iconview.unfreeze
-      expect(ui.model.iter_n_children).to eq regular_library.count
 
       # This triggers the #on_books_selection_changed callback
       ui.select_a_book regular_library.first
 
-      expect(ui.iconview.selected_items).not_to be_empty
+      aggregate_failures do
+        expect(ui.model.iter_n_children).to eq regular_library.count
+        expect(ui.iconview.selected_items).not_to be_empty
+      end
     end
   end
 

--- a/spec/alexandria/ui/ui_manager_spec.rb
+++ b/spec/alexandria/ui/ui_manager_spec.rb
@@ -10,7 +10,7 @@ describe Alexandria::UI::UIManager do
   let(:main_app) { instance_double(Alexandria::UI::MainApp) }
 
   it "works" do
-    described_class.new main_app
+    expect { described_class.new main_app }.not_to raise_error
   end
 
   describe "#on_new" do


### PR DESCRIPTION
- Replace assert_correct_search_result with an RSpec matcher
- Fix RSpec/NoExpectationExample offenses
- Silence RSpec/NoExpectationExample where it gives incorrect result
- Fix RSpec/MultipleExpectations offenses
