### PR TITLE
Fix RSpec/PredicateMatcher offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -76,16 +76,6 @@ RSpec/FilePath:
     - 'spec/alexandria/ui/iconview_spec.rb'
     - 'spec/alexandria/ui/sound_spec.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Strict, EnforcedStyle, AllowedExplicitMatchers.
-# SupportedStyles: inflected, explicit
-RSpec/PredicateMatcher:
-  Exclude:
-    - 'spec/alexandria/library_spec.rb'
-    - 'spec/alexandria/scanners/cue_cat_spec.rb'
-    - 'spec/alexandria/ui/confirm_erase_dialog_spec.rb'
-    - 'spec/alexandria/ui/skip_entry_dialog_spec.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 Rake/Desc:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -81,9 +81,7 @@ RSpec/FilePath:
 # SupportedStyles: inflected, explicit
 RSpec/PredicateMatcher:
   Exclude:
-    - 'spec/alexandria/export_library_spec.rb'
     - 'spec/alexandria/library_spec.rb'
-    - 'spec/alexandria/library_store_spec.rb'
     - 'spec/alexandria/scanners/cue_cat_spec.rb'
     - 'spec/alexandria/ui/confirm_erase_dialog_spec.rb'
     - 'spec/alexandria/ui/skip_entry_dialog_spec.rb'

--- a/spec/alexandria/export_library_spec.rb
+++ b/spec/alexandria/export_library_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Alexandria::ExportLibrary do
       index = File.join(outfile, "index.html")
 
       aggregate_failures do
-        expect(File.exist?(outfile)).to be_truthy
-        expect(File.exist?(index)).to be_truthy
+        expect(outfile).to be_an_existing_file
+        expect(index).to be_an_existing_file
         expect(File.size(index)).to be_nonzero
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe Alexandria::ExportLibrary do
     it "can export unsorted" do
       format.invoke(my_library, unsorted, outfile)
       aggregate_failures do
-        expect(File.exist?(outfile)).to be_truthy
+        expect(outfile).to be_an_existing_file
         expect(File.size(outfile)).to be_nonzero
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe Alexandria::ExportLibrary do
     it "can export unsorted" do
       format.invoke(my_library, unsorted, outfile)
       aggregate_failures do
-        expect(File.exist?(outfile)).to be_truthy
+        expect(outfile).to be_an_existing_file
         expect(File.size(outfile)).to be_nonzero
       end
     end
@@ -96,7 +96,7 @@ RSpec.describe Alexandria::ExportLibrary do
     it "can export unsorted" do
       format.invoke(my_library, unsorted, outfile)
       aggregate_failures do
-        expect(File.exist?(outfile)).to be_truthy
+        expect(outfile).to be_an_existing_file
         expect(File.size(outfile)).to be_nonzero
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe Alexandria::ExportLibrary do
     it "can export unsorted" do
       format.invoke(my_library, unsorted, outfile)
       aggregate_failures do
-        expect(File.exist?(outfile)).to be_truthy
+        expect(outfile).to be_an_existing_file
         expect(File.size(outfile)).to be_nonzero
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe Alexandria::ExportLibrary do
       index = File.join(outfile, "index.linx")
 
       aggregate_failures do
-        expect(File.exist?(outfile)).to be_truthy
+        expect(outfile).to be_an_existing_file
         expect(File.size(index)).to be_nonzero
       end
     end

--- a/spec/alexandria/library_spec.rb
+++ b/spec/alexandria/library_spec.rb
@@ -22,7 +22,7 @@ describe Alexandria::Library do
   describe "#valid_isbn?" do
     it "returns a true value for valid isbns" do
       ["014143984X", "0-345-43192-8"].each do |x|
-        expect(described_class.valid_isbn?(x)).to be_truthy
+        expect(described_class.valid_isbn?(x)).to be true
       end
     end
   end
@@ -30,12 +30,12 @@ describe Alexandria::Library do
   describe "#valid_ean?" do
     it "returns a true value for valid EANs" do
       aggregate_failures do
-        expect(described_class.valid_ean?("9780345431929")).to be_truthy
-        expect(described_class.valid_ean?("978034543192912345")).to be_truthy
+        expect(described_class.valid_ean?("9780345431929")).to be true
+        expect(described_class.valid_ean?("978034543192912345")).to be true
 
         # Regression test: this EAN has a checksum of 10, which should be
         # treated like a checksum of 0.
-        expect(described_class.valid_ean?("9784047041790")).to be_truthy
+        expect(described_class.valid_ean?("9784047041790")).to be true
       end
     end
 
@@ -46,7 +46,7 @@ describe Alexandria::Library do
 
       aggregate_failures do
         invalid_eans.each do |ean|
-          expect(described_class.valid_ean?(ean)).to be_falsey
+          expect(described_class.valid_ean?(ean)).to be false
         end
       end
     end
@@ -54,16 +54,16 @@ describe Alexandria::Library do
 
   describe "#valid_upc?" do
     it "returns a true value for valid UPCs" do
-      expect(described_class.valid_upc?("97803454319312356")).to be_truthy
+      expect(described_class.valid_upc?("97803454319312356")).to be true
     end
 
     it "returns a false value for invalid UPCs" do
       aggregate_failures do
-        expect(described_class.valid_upc?("978034543193123567")).to be_falsey
-        expect(described_class.valid_upc?("9780345431931235")).to be_falsey
+        expect(described_class.valid_upc?("978034543193123567")).to be false
+        expect(described_class.valid_upc?("9780345431931235")).to be false
 
-        expect(described_class.valid_upc?("97803454319412356")).to be_falsey
-        expect(described_class.valid_upc?("97803454319212356")).to be_falsey
+        expect(described_class.valid_upc?("97803454319412356")).to be false
+        expect(described_class.valid_upc?("97803454319212356")).to be false
       end
     end
   end
@@ -155,7 +155,7 @@ describe Alexandria::Library do
       malory_book = my_library.find { |b| b.isbn == "9780192812179" }
       aggregate_failures do
         expect(malory_book.publisher).to eq("Oxford University Press")
-        expect(malory_book.authors.include?("Vinaver")).to be_truthy
+        expect(malory_book.authors).to include "Vinaver"
         expect(malory_book.version).to eq(Alexandria::DATA_VERSION)
       end
     end

--- a/spec/alexandria/library_spec.rb
+++ b/spec/alexandria/library_spec.rb
@@ -238,10 +238,10 @@ describe Alexandria::Library do
       described_class.move(source, target, book)
 
       aggregate_failures do
-        expect(File.exist?(source.yaml(book))).to be_falsey
-        expect(File.exist?(source.cover(book))).to be_falsey
-        expect(File.exist?(target.yaml(book))).to be_truthy
-        expect(File.exist?(target.cover(book))).to be_truthy
+        expect(source.yaml(book)).not_to be_an_existing_file
+        expect(source.cover(book)).not_to be_an_existing_file
+        expect(target.yaml(book)).to be_an_existing_file
+        expect(target.cover(book)).to be_an_existing_file
       end
     end
   end
@@ -260,7 +260,7 @@ describe Alexandria::Library do
 
     it "moves the library's directory" do
       my_library.name = "Really Empty"
-      expect(File.exist?(File.join(TESTDIR, "Really Empty"))).to be_truthy
+      expect(File.join(TESTDIR, "Really Empty")).to be_an_existing_file
     end
   end
 end

--- a/spec/alexandria/library_store_spec.rb
+++ b/spec/alexandria/library_store_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Alexandria::LibraryStore do
         aggregate_failures do
           expect(smart_libs.size).to eq 5
           smart_libs.each do |lib|
-            expect(File.exist?(lib.yaml)).to be_truthy
+            expect(lib.yaml).to be_an_existing_file
           end
         end
       end

--- a/spec/alexandria/scanners/cue_cat_spec.rb
+++ b/spec/alexandria/scanners/cue_cat_spec.rb
@@ -29,14 +29,14 @@ describe Alexandria::Scanners::CueCat do
 
   it "refuses to detect incomplete scans" do
     aggregate_failures do
-      partials.each { |scan| expect(cuecat.match?(scan)).not_to be_truthy }
+      partials.each { |scan| expect(cuecat.match?(scan)).to be false }
     end
   end
 
   it "detects complete scans" do
     aggregate_failures do
-      expect(cuecat.match?(scans[:isbn])).to be_truthy
-      expect(cuecat.match?(scans[:ib5])).to be_truthy
+      expect(cuecat.match?(scans[:isbn])).to be true
+      expect(cuecat.match?(scans[:ib5])).to be true
     end
   end
 

--- a/spec/alexandria/ui/confirm_erase_dialog_spec.rb
+++ b/spec/alexandria/ui/confirm_erase_dialog_spec.rb
@@ -17,14 +17,14 @@ describe Alexandria::UI::ConfirmEraseDialog do
     let(:instance) { described_class.new parent, "foo-file" }
     let(:dialog) { instance.dialog }
 
-    it "works when response is cancel" do
+    it "returns false when response is cancel" do
       allow(dialog).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
-      expect(instance.erase?).to be_falsey
+      expect(instance.erase?).to be false
     end
 
-    it "works when response is OK" do
+    it "returns true when response is OK" do
       allow(dialog).to receive(:run).and_return(Gtk::ResponseType::OK)
-      expect(instance.erase?).to be_truthy
+      expect(instance.erase?).to be true
     end
   end
 end

--- a/spec/alexandria/ui/skip_entry_dialog_spec.rb
+++ b/spec/alexandria/ui/skip_entry_dialog_spec.rb
@@ -17,14 +17,14 @@ describe Alexandria::UI::SkipEntryDialog do
     let(:instance) { described_class.new parent, "Foo" }
     let(:dialog) { instance.dialog }
 
-    it "works when response is cancel" do
+    it "returns false when response is cancel" do
       allow(dialog).to receive(:run).and_return(Gtk::ResponseType::CANCEL)
-      expect(instance.continue?).to be_falsey
+      expect(instance.continue?).to be false
     end
 
-    it "works when response is OK" do
+    it "returns true when response is OK" do
       allow(dialog).to receive(:run).and_return(Gtk::ResponseType::OK)
-      expect(instance.continue?).to be_truthy
+      expect(instance.continue?).to be true
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,12 @@ RSpec::Matchers.define :have_correct_search_result_for do |query|
   end
 end
 
+RSpec::Matchers.define :be_an_existing_file do
+  match do |filename|
+    File.exist? filename
+  end
+end
+
 Alexandria::UI::Icons.init
 
 test_store = Alexandria::LibraryStore.new(TESTDIR)


### PR DESCRIPTION
- Use custom be_an_existing_file matcher
- Silence RSpec/PredicateMatcher offenses
