### PR TITLE
Correct new RuboCop offenses

### DIFF
--- a/lib/alexandria/book_providers/worldcat.rb
+++ b/lib/alexandria/book_providers/worldcat.rb
@@ -3,7 +3,6 @@
 # This file is part of Alexandria.
 #
 # See the file README.md for authorship and licensing information.
-# frozen_string_literal: true
 
 # http://en.wikipedia.org/wiki/WorldCat
 # See http://www.oclc.org/worldcat/policies/terms/

--- a/lib/alexandria/export_library.rb
+++ b/lib/alexandria/export_library.rb
@@ -357,8 +357,8 @@ module Alexandria
     def to_bibtex
       generator = "Alexandria " + Alexandria::DISPLAY_VERSION
       bibtex = +""
-      bibtex << "\%Generated on #{Date.today} by: #{generator}\n"
-      bibtex << "\%\n"
+      bibtex << "%Generated on #{Date.today} by: #{generator}\n"
+      bibtex << "%\n"
       bibtex << "\n"
 
       auths = Hash.new(0)
@@ -402,7 +402,7 @@ module Alexandria
       my_str.gsub!(/\{/, "\\{")
       my_str.gsub!(/\}/, "\\}")
       my_str.gsub!(/_/, "\\_")
-      my_str.gsub!(/\$/, "\\\$")
+      my_str.gsub!(/\$/, "\\$")
       my_str.gsub!(/"(.+)"/, "``\1''")
       my_str
     end

--- a/spec/alexandria/ui/main_app_spec.rb
+++ b/spec/alexandria/ui/main_app_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 # This file is part of Alexandria.
 #
 # See the file README.md for authorship and licensing information.

--- a/spec/alexandria/ui/main_app_spec.rb
+++ b/spec/alexandria/ui/main_app_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_string_literal: true
 
 # This file is part of Alexandria.
 #

--- a/util/rake/fileinstall.rb
+++ b/util/rake/fileinstall.rb
@@ -197,7 +197,7 @@ class FileInstallTask < Rake::TaskLib
       part.gsub!("*", "[^\\/]*")
       part.gsub!("?", "[^\\/]")
     end
-    pattern = real_parts.join("([^\/]+\/)*")
+    pattern = real_parts.join("([^/]+/)*")
     /(#{pattern})/
   end
 


### PR DESCRIPTION
This corrects offenses flagged newly by cops in RuboCop 1.37.0.

- Autocorrect Lint/DuplicateMagicComment
- Autocorrect Style/RedundantStringEscape
- Autocorrect Layout/EmptyLines
