### PR TITLE
Drop explicit psych dependency

### DIFF
--- a/alexandria-book-collection-manager.gemspec
+++ b/alexandria-book-collection-manager.gemspec
@@ -54,7 +54,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "image_size", ["~> 3.0"]
   spec.add_runtime_dependency "marc", ">= 1.0", "< 1.3"
   spec.add_runtime_dependency "nokogiri", ["~> 1.11"]
-  spec.add_runtime_dependency "psych", ">= 3.2", "< 4.1"
   spec.add_runtime_dependency "zoom", ["~> 0.5.0"]
 
   spec.add_development_dependency "gnome_app_driver", "~> 0.3.2"


### PR DESCRIPTION
This dependency is no longer needed since all supported versions of Ruby come with psych 3.1 or later by default. This should be enough to support the yaml features used by alexandria.
