### PR TITLE
Keep building on Ubuntu 20.04 for the time being

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ name: CI
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -50,7 +50,7 @@ jobs:
 
   rubocop:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Recently, GitHub Actions changed ubuntu-latest from 20.04 to 22.04, causing build failures due to changes in apt packages.

Downgrade for now to allow other pull requests to be tested and merged.
