### PR TITLE
Do not attempt to process MARC using ancient interface

### DIFF
--- a/lib/alexandria/book_providers/z3950_provider.rb
+++ b/lib/alexandria/book_providers/z3950_provider.rb
@@ -80,19 +80,7 @@ module Alexandria
       end
 
       def marc_to_book(marc_txt, isbn)
-        begin
-          marc = MARC::Record.new_from_marc(marc_txt, forgiving: true)
-        rescue StandardError => ex
-          log.error { ex.message }
-          log.error { ex.backtrace.join("> \n") }
-          begin
-            marc = MARC::Record.new(marc_txt)
-          rescue StandardError => ex
-            log.error { ex.message }
-            log.error { ex.backtrace.join("> \n") }
-            raise ex
-          end
-        end
+        marc = MARC::Record.new_from_marc(marc_txt, forgiving: true)
 
         log.debug do
           msg = "Parsing MARC"


### PR DESCRIPTION
Alexandria's version requirements ensure that the `MARC::Record.new_from_marc` method is available, so do not attempt to use the old interface if it fails.
