### PR TITLE
Update gstreamer and gtk3 dependencies to 4.1.6

### DIFF
--- a/alexandria-book-collection-manager.gemspec
+++ b/alexandria-book-collection-manager.gemspec
@@ -49,8 +49,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "alexandria-zoom", ["~> 0.6.0"]
   spec.add_runtime_dependency "gettext", ["~> 3.1"]
-  spec.add_runtime_dependency "gstreamer", ["4.0.8"]
-  spec.add_runtime_dependency "gtk3", ["4.0.8"]
+  spec.add_runtime_dependency "gstreamer", "~> 4.1.6"
+  spec.add_runtime_dependency "gtk3", "~> 4.1.6"
   spec.add_runtime_dependency "htmlentities", ["~> 4.3"]
   spec.add_runtime_dependency "image_size", ["~> 3.0"]
   spec.add_runtime_dependency "marc", ">= 1.0", "< 1.3"


### PR DESCRIPTION
Version 4.1.6 fixes a TypeError that causes builds in CI to fail for versions 4.0.9 through 4.1.5.

See https://github.com/ruby-gnome/ruby-gnome/commit/3d52996e30b688a36264ca875dc62e768d4837ca

Makes #217 and #218 obsolete.