### PR TITLE
Fix the build

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2.0-preview2"]
+        ruby: ["2.7", "3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v3

--- a/alexandria-book-collection-manager.gemspec
+++ b/alexandria-book-collection-manager.gemspec
@@ -48,8 +48,8 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
 
   spec.add_runtime_dependency "gettext", ["~> 3.1"]
-  spec.add_runtime_dependency "gstreamer", ["~> 4.0.2"]
-  spec.add_runtime_dependency "gtk3", ["~> 4.0.2"]
+  spec.add_runtime_dependency "gstreamer", ["4.0.8"]
+  spec.add_runtime_dependency "gtk3", ["4.0.8"]
   spec.add_runtime_dependency "htmlentities", ["~> 4.3"]
   spec.add_runtime_dependency "image_size", ["~> 3.0"]
   spec.add_runtime_dependency "marc", ">= 1.0", "< 1.3"

--- a/lib/alexandria/book_providers/z3950_provider.rb
+++ b/lib/alexandria/book_providers/z3950_provider.rb
@@ -171,7 +171,7 @@ module Alexandria
           end
           conn.search(pqf)
         rescue StandardError => ex
-          if /1005/.match?(ex.message) &&
+          if ex.message.include?("1005") &&
               prefs.variable_named("piggyback") && prefs["piggyback"]
             log.error { "Z39.50 search failed:: #{ex.message}" }
             log.info { "Turning off piggybacking for this provider" }

--- a/lib/alexandria/library_store.rb
+++ b/lib/alexandria/library_store.rb
@@ -192,7 +192,7 @@ module Alexandria
 
       # The string is removed on load, but can't make it stick, maybe has to do with cache
 
-      if /!str:Amazon::Search::Response/.match?(text)
+      if text.include?("!str:Amazon::Search::Response")
         log.debug { "Removing Ruby/Amazon strings from #{name}" }
         text.gsub!("!str:Amazon::Search::Response", "")
       end

--- a/lib/alexandria/preferences.rb
+++ b/lib/alexandria/preferences.rb
@@ -167,7 +167,7 @@ module Alexandria
     end
 
     def exec_gconf_set(var_path, new_value)
-      if /cols_width/.match?(var_path)
+      if var_path.include?("cols_width")
         log.debug { new_value }
 
         # new_value = {}
@@ -178,7 +178,7 @@ module Alexandria
         new_value = new_value.gsub(/"/, '\\"')
         value_str = "\"#{new_value}\""
       end
-      log.debug { value_str } if /cols_width/.match?(var_path)
+      log.debug { value_str } if var_path.include?("cols_width")
       `gconftool-2 --type #{type} --set #{var_path} #{value_str}`
     end
 

--- a/spec/alexandria/library_collection_spec.rb
+++ b/spec/alexandria/library_collection_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Alexandria::LibraryCollection do
       collection = described_class.instance
       collection.reload
       library = collection.all_libraries.first
-      expect(collection.ruined_books).to match_array [[nil, "0740704923", library]]
+      expect(collection.ruined_books).to eq [[nil, "0740704923", library]]
     end
   end
 end

--- a/spec/alexandria/library_spec.rb
+++ b/spec/alexandria/library_spec.rb
@@ -210,7 +210,7 @@ describe Alexandria::Library do
       my_library_reloaded = loader.load_all_libraries[0]
 
       expect(my_library_reloaded.map(&:publisher))
-        .to match_array ["O'Reilley", "Addison Wesley"]
+        .to contain_exactly("O'Reilley", "Addison Wesley")
     end
   end
 

--- a/spec/alexandria/library_store_spec.rb
+++ b/spec/alexandria/library_store_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe Alexandria::LibraryStore do
       aggregate_failures do
         expect(result.count).to eq 1
         expect(result.first.map(&:title))
-          .to match_array ["Pattern Recognition", "Bonjour Tristesse",
-                           "An Artist of the Floating World", "The Dispossessed",
-                           "Neverwhere"]
+          .to contain_exactly("Pattern Recognition", "Bonjour Tristesse",
+                              "An Artist of the Floating World", "The Dispossessed",
+                              "Neverwhere")
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Alexandria::LibraryStore do
       FileUtils.touch File.join(TESTDIR, "My Library", "0740704923.yaml")
       result = loader.load_all_libraries
       library = result.first
-      expect(library.ruined_books).to match_array ["0740704923"]
+      expect(library.ruined_books).to eq ["0740704923"]
     end
 
     it "skips empty files with names that are not valid ISBNs" do


### PR DESCRIPTION
These changes should make the CI build pass. From there, we can start updating dependencies and platforms.

- Pin gstreamer and gtk3 to version 4.0.8
- Fix new RuboCop offenses
- Drop 3.2.0-preview2 build
