### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.0
           bundler-cache: true
 
       - name: Run RuboCop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - 'lib/alexandria/default_preferences.rb'
     - 'pkg/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/alexandria-book-collection-manager.gemspec
+++ b/alexandria-book-collection-manager.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "http://www.github.com/mvz/alexandria-book-collection-manager"
   spec.license = "GPL-2.0+"
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.metadata["rubygems_mfa_required"] = "true"
 

--- a/lib/alexandria/book_providers/thalia_provider.rb
+++ b/lib/alexandria/book_providers/thalia_provider.rb
@@ -20,7 +20,7 @@ module Alexandria
       include Logging
 
       SITE = "https://www.thalia.de"
-      BASE_SEARCH_URL = "#{SITE}/shop/bde_bu_hg_startseite/suche/?%s=%s" # type,term
+      BASE_SEARCH_URL = "#{SITE}/shop/bde_bu_hg_startseite/suche/?%s=%s".freeze # type,term
 
       def initialize
         super("Thalia", "Thalia (Germany)")

--- a/lib/alexandria/book_providers/world_cat_provider.rb
+++ b/lib/alexandria/book_providers/world_cat_provider.rb
@@ -24,7 +24,7 @@ module Alexandria
       include Logging
 
       SITE = "https://www.worldcat.org"
-      BASE_SEARCH_URL = "#{SITE}/search?q=%s%s&qt=advanced" # type, term
+      BASE_SEARCH_URL = "#{SITE}/search?q=%s%s&qt=advanced".freeze # type, term
 
       def initialize
         super("WorldCat", "WorldCat")

--- a/lib/alexandria/config.rb
+++ b/lib/alexandria/config.rb
@@ -3,8 +3,8 @@
 module Alexandria
   module Config
     SHARE_DIR = File.expand_path("../../share", File.dirname(__FILE__))
-    SOUNDS_DIR = "#{SHARE_DIR}/sounds/alexandria"
-    DATA_DIR = "#{SHARE_DIR}/alexandria"
+    SOUNDS_DIR = "#{SHARE_DIR}/sounds/alexandria".freeze
+    DATA_DIR = "#{SHARE_DIR}/alexandria".freeze
     MAIN_DATA_DIR = DATA_DIR
   end
 end

--- a/lib/alexandria/library_store.rb
+++ b/lib/alexandria/library_store.rb
@@ -45,7 +45,7 @@ module Alexandria
       library = Library.new(name, self)
       FileUtils.mkdir_p(library.path)
       Dir.chdir(library.path) do
-        Dir["*" + Library::EXT[:book]].sort.each do |filename|
+        Dir["*" + Library::EXT[:book]].each do |filename|
           test[1] = filename if (test[0]).zero?
 
           unless File.size? test[1]

--- a/lib/alexandria/library_store.rb
+++ b/lib/alexandria/library_store.rb
@@ -9,7 +9,7 @@ module Alexandria
     include Logging
 
     FIX_BIGNUM_REGEX =
-      %r{loaned_since:\s*(!ruby/object:Bignum\s*)?(\d+)\n}.freeze
+      %r{loaned_since:\s*(!ruby/object:Bignum\s*)?(\d+)\n}
 
     include GetText
     bindtextdomain(Alexandria::TEXTDOMAIN, charset: "UTF-8")

--- a/lib/alexandria/models/book.rb
+++ b/lib/alexandria/models/book.rb
@@ -15,7 +15,7 @@ module Alexandria
 
     DEFAULT_RATING = 0
     MAX_RATING_STARS = 5
-    VALID_RATINGS = (DEFAULT_RATING..MAX_RATING_STARS).freeze
+    VALID_RATINGS = (DEFAULT_RATING..MAX_RATING_STARS)
 
     def initialize(title, authors, isbn, publisher, publishing_year,
                    edition)

--- a/tasks/setup.rb
+++ b/tasks/setup.rb
@@ -28,5 +28,5 @@ require "rake/clean"
 
 # Load the other rake files in the tasks folder
 tasks_dir = __dir__
-rakefiles = Dir.glob(File.join(tasks_dir, "*.rake")).sort
+rakefiles = Dir.glob(File.join(tasks_dir, "*.rake"))
 import(*rakefiles)


### PR DESCRIPTION
Ruby 2.7 is EOL and causes regular intermittent core dumps in CI.

Bumping the minimum Ruby version also triggers some new RuboCop offenses, which were corrected.

- Drop support for Ruby 2.7
- Autocorrect Lint/RedundantDirGlobSort
- Autocorrect Style/MutableConstant
- Autocorrect Style/RedundantFreeze
