### PR TITLE
Ensure fresh temporary directories are used each time

### DIFF
--- a/lib/alexandria/export_library.rb
+++ b/lib/alexandria/export_library.rb
@@ -52,16 +52,18 @@ module Alexandria
     end
 
     def export_as_tellico_xml_archive(filename)
-      File.open(File.join(Dir.tmpdir, "tellico.xml"), "w") do |io|
+      tmpdir = Dir.mktmpdir "tellico_export"
+
+      File.open(File.join(tmpdir, "tellico.xml"), "w") do |io|
         to_tellico_document.write(io, 0)
       end
-      copy_covers(File.join(Dir.tmpdir, "images"))
-      Dir.chdir(Dir.tmpdir) do
+      copy_covers(File.join(tmpdir, "images"))
+      Dir.chdir(tmpdir) do
         output = `zip -q -r \"#{filename}\" tellico.xml images 2>&1`
         raise output unless $CHILD_STATUS.success?
       end
-      FileUtils.rm_rf(File.join(Dir.tmpdir, "images"))
-      FileUtils.rm(File.join(Dir.tmpdir, "tellico.xml"))
+      FileUtils.rm_rf(File.join(tmpdir, "images"))
+      FileUtils.rm(File.join(tmpdir, "tellico.xml"))
     end
 
     def export_as_isbn_list(filename)

--- a/lib/alexandria/import_library.rb
+++ b/lib/alexandria/import_library.rb
@@ -71,9 +71,7 @@ module Alexandria
       log.debug { "Starting import_as_tellico_xml_archive... " }
       return nil unless system("unzip -qqt \"#{filename}\"")
 
-      tmpdir = File.join(Dir.tmpdir, "tellico_export")
-      FileUtils.rm_rf(tmpdir)
-      Dir.mkdir(tmpdir)
+      tmpdir = Dir.mktmpdir "tellico_import"
       Dir.chdir(tmpdir) do
         system("unzip -qq \"#{filename}\"")
         file = File.exist?("bookcase.xml") ? "bookcase.xml" : "tellico.xml"

--- a/lib/alexandria/ui/new_book_dialog_manual.rb
+++ b/lib/alexandria/ui/new_book_dialog_manual.rb
@@ -14,13 +14,13 @@ module Alexandria
       extend GetText
       GetText.bindtextdomain(Alexandria::TEXTDOMAIN, charset: "UTF-8")
 
-      TMP_COVER_FILE = File.join(Dir.tmpdir, "tmp_cover")
       def initialize(parent, library, &on_add_cb)
-        super(parent, TMP_COVER_FILE)
+        tmp_cover_file = File.join(Dir.mktmpdir("cover"), "tmp_cover")
+        super(parent, tmp_cover_file)
 
         @library = library
         @on_add_cb = on_add_cb
-        FileUtils.rm_f(TMP_COVER_FILE)
+        FileUtils.rm_f(@cover_file)
 
         cancel_button = Gtk::Button.new(stock_id: Gtk::Stock::CANCEL)
         cancel_button.signal_connect("clicked") { on_cancel }
@@ -110,8 +110,8 @@ module Alexandria
         book.tags = @entry_tags.text.split
         @library << book
         @library.save(book)
-        if File.exist?(TMP_COVER_FILE) && !@delete_cover_file
-          FileUtils.cp(TMP_COVER_FILE, @library.cover(book))
+        if File.exist?(@cover_file) && !@delete_cover_file
+          FileUtils.cp(@cover_file, @library.cover(book))
         end
         @on_add_cb.call(book)
         @book_properties_dialog.destroy

--- a/spec/alexandria/export_library_spec.rb
+++ b/spec/alexandria/export_library_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Alexandria::ExportLibrary do
   let(:format) { Alexandria::ExportFormat.all.find { |it| it.message == message } }
   let(:outfile) do
     outfile_base = format.ext ? "my-library.#{format.ext}" : "my-library"
-    File.join(Dir.tmpdir, outfile_base)
+    File.join(Dir.mktmpdir, outfile_base)
   end
   let(:unsorted) { Alexandria::LibrarySortOrder::Unsorted.new }
 


### PR DESCRIPTION
`Dir.tmpdir` simply returns the existing directory for temporary files. This is unsafe. Use `Dir.mktmpdir` instead to get a unique temporary directory each time.
