### PR TITLE
Gracefully handle ZOOM timeout in specs

### DIFF
--- a/lib/alexandria/book_providers.rb
+++ b/lib/alexandria/book_providers.rb
@@ -36,6 +36,8 @@ module Alexandria
 
     class SearchError < StandardError; end
 
+    class ConnectionError < SearchError; end
+
     class NoResultsError < SearchError; end
 
     class TooManyResultsError < SearchError; end

--- a/spec/alexandria/book_providers/z3950_provider_spec.rb
+++ b/spec/alexandria/book_providers/z3950_provider_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This file is part of Alexandria.
+#
+# See the file README.md for authorship and licensing information.
+
+require "spec_helper"
+
+describe Alexandria::BookProviders::Z3950Provider do
+  let(:zoom_connection) { instance_double(ZOOM::Connection) }
+
+  before do
+    allow(ZOOM::Connection).to receive(:new).and_return zoom_connection
+  end
+
+  it "raises a custom error when a timeout occurs" do
+    allow(zoom_connection).to receive(:connect).and_raise RuntimeError, "Timeout (10007)"
+    expect do
+      described_class.new.search("9781853260803", Alexandria::BookProviders::SEARCH_BY_ISBN)
+    end.to raise_error Alexandria::BookProviders::ConnectionError
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ RSpec::Matchers.define :have_correct_search_result_for do |query|
       results = provider.instance.search(query, Alexandria::BookProviders::SEARCH_BY_ISBN)
     rescue SocketError
       skip "Service is offline"
+    rescue Alexandria::BookProviders::ConnectionError
+      skip "Connection failed"
     end
 
     expect(results).to be_instance_of(Array)


### PR DESCRIPTION
- Raise ConnectionError instead of RuntimeError when ZOOM times out
- Skip provider spec if connection fails
