### PR TITLE
Fix new RuboCop offenses

### DIFF
--- a/lib/alexandria/book_providers.rb
+++ b/lib/alexandria/book_providers.rb
@@ -178,7 +178,7 @@ module Alexandria
           var = variable_named(obj)
           var&.value
         when Integer
-          super(obj)
+          super
         end
       end
 

--- a/lib/alexandria/book_providers/thalia_provider.rb
+++ b/lib/alexandria/book_providers/thalia_provider.rb
@@ -116,10 +116,9 @@ module Alexandria
             title = div["data-titel"]
 
             if (author_p = doc % "p.aim-author")
-              authors = []
               author_links = author_p / :a
-              author_links.each do |a|
-                authors << a.inner_text.strip
+              authors = author_links.map do |a|
+                a.inner_text.strip
               end
             end
 

--- a/lib/alexandria/book_providers/website_based_provider.rb
+++ b/lib/alexandria/book_providers/website_based_provider.rb
@@ -30,7 +30,7 @@ module Alexandria
   class BookProviders
     class WebsiteBasedProvider < GenericProvider
       def initialize(name, fullname = nil)
-        super(name, fullname)
+        super
         @htmlentities = HTMLEntities.new
       end
 

--- a/lib/alexandria/import_library_csv.rb
+++ b/lib/alexandria/import_library_csv.rb
@@ -46,7 +46,7 @@ module Alexandria
 
   class GoodreadsCSVImport < CSVImport
     def initialize(header)
-      super(header)
+      super
       @title = index_of("Title")
       @author = index_of("Author")
       @additional_authors = index_of("Additional Authors")
@@ -119,7 +119,7 @@ module Alexandria
 
   class LibraryThingCSVImport < CSVImport
     def initialize(header)
-      super(header)
+      super
       @title = index_of("'TITLE'")
       @author = index_of("'AUTHOR (first, last)'")
       @isbn = index_of("'ISBN'")

--- a/lib/alexandria/smart_library.rb
+++ b/lib/alexandria/smart_library.rb
@@ -328,7 +328,7 @@ module Alexandria
                                proc { |x| x })
         IS_NOT_TRUE = Operator.new(:is_not_true,
                                    _("is not set"),
-                                   proc { |x| !x })
+                                   proc(&:!))
         IS = Operator.new(:is,
                           _("is"),
                           proc { |x, y| x == y })

--- a/lib/alexandria/ui/multi_drag_treeview.rb
+++ b/lib/alexandria/ui/multi_drag_treeview.rb
@@ -79,8 +79,6 @@ module Alexandria
     def motion_notify_event(event)
       if drag_check_threshold(@context.x, @context.y, event.x, event.y)
         stop_drag_check
-        paths = []
-        selection.each { |_model, path, _iter| paths << path }
         @context.drag_context = drag_begin(@context.source_targets,
                                            @context.source_actions,
                                            @context.pressed_button,

--- a/lib/alexandria/ui/new_book_dialog.rb
+++ b/lib/alexandria/ui/new_book_dialog.rb
@@ -427,7 +427,7 @@ module Alexandria
             @treeview_results.model.clear
             @entry_search.grab_focus
           else
-            @button_add.sensitive = true #
+            @button_add.sensitive = true
             @entry_isbn.text = "" # blank ISBN field
             @entry_isbn.grab_focus
           end

--- a/lib/alexandria/ui/new_book_dialog_manual.rb
+++ b/lib/alexandria/ui/new_book_dialog_manual.rb
@@ -89,8 +89,7 @@ module Alexandria
           raise AddError, _("A binding must be provided.")
         end
 
-        authors = []
-        @treeview_authors.model.each { |_m, _p, i| authors << i[0] }
+        authors = @treeview_authors.model.map { |_m, _p, i| i[0] }
         if authors.empty?
           raise AddError, _("At least one author must be " \
                             "provided.")

--- a/lib/alexandria/ui/new_smart_library_dialog.rb
+++ b/lib/alexandria/ui/new_smart_library_dialog.rb
@@ -11,7 +11,7 @@ module Alexandria
       GetText.bindtextdomain(Alexandria::TEXTDOMAIN, charset: "UTF-8")
 
       def initialize(parent)
-        super(parent)
+        super
 
         dialog.add_buttons([Gtk::Stock::CANCEL, :cancel],
                            [Gtk::Stock::NEW, :ok])

--- a/lib/alexandria/ui/preferences_dialog.rb
+++ b/lib/alexandria/ui/preferences_dialog.rb
@@ -301,9 +301,8 @@ module Alexandria
       end
 
       def update_priority
-        priority = []
-        @treeview_providers.model.each do |_model, _path, iter|
-          priority << iter[1]
+        priority = @treeview_providers.model.map do |_model, _path, iter|
+          iter[1]
         end
         Preferences.instance.providers_priority = priority
         BookProviders.instance.update_priority

--- a/lib/alexandria/ui/ui_manager.rb
+++ b/lib/alexandria/ui/ui_manager.rb
@@ -1083,9 +1083,8 @@ module Alexandria
 
           @actiongroup.remove_action(action)
         end
-        actions = []
-        @libraries.all_regular_libraries.each do |library|
-          actions << [
+        actions = @libraries.all_regular_libraries.map do |library|
+          [
             library.action_name, nil,
             _("In '_%s'") % library.name,
             nil, nil, proc { move_selected_books_to_library(library) }


### PR DESCRIPTION
- Autocorrect Style/SuperArguments
- Autocorrect Layout/EmptyComment
- Autocorrect Style/SymbolProc
- Remove iteration whose result was never used
- Fix Style/MapIntoArray offenses
