### PR TITLE
Loosen, simplify and update marc version requirement

### DIFF
--- a/alexandria-book-collection-manager.gemspec
+++ b/alexandria-book-collection-manager.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gtk3", "~> 4.2.0"
   spec.add_dependency "htmlentities", ["~> 4.3"]
   spec.add_dependency "image_size", ["~> 3.0"]
-  spec.add_dependency "marc", ">= 1.0", "< 1.3"
+  spec.add_dependency "marc", "~> 1.3"
   spec.add_dependency "nokogiri", ["~> 1.11"]
   spec.add_dependency "observer", "~> 0.1.2"
 


### PR DESCRIPTION
This changes the minimum required version to 1.3.0 since 1.2.0 contains some bugfixes and 1.3.0 drops support for Ruby 2.2 and hence a dependency on unf.
