### PR TITLE
Ensure GitHub Actions Runner OS includes gconf2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ name: CI
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -60,7 +60,7 @@ jobs:
 
   lint:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This means that for now, jobs run on Ubuntu 22.04.
