### PR TITLE
Update rubocop gems and config, and fix offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-performance
   - rubocop-rake
   - rubocop-rspec

--- a/Rakefile
+++ b/Rakefile
@@ -148,7 +148,7 @@ file "lib/alexandria/default_preferences.rb" => ["Rakefile", SCHEMA_PATH] do |f|
       end
       default = ary.inspect
     else
-      default = convert_with_type(default, type).inspect.to_s
+      default = convert_with_type(default, type).inspect
     end
 
     generated_lines << varname.inspect + " => " + default

--- a/alexandria-book-collection-manager.gemspec
+++ b/alexandria-book-collection-manager.gemspec
@@ -62,11 +62,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "gnome_app_driver", "~> 0.3.2"
   spec.add_development_dependency "rake", ["~> 13.0"]
   spec.add_development_dependency "rspec", ["~> 3.0"]
-  spec.add_development_dependency "rubocop", "~> 1.56"
-  spec.add_development_dependency "rubocop-i18n", "~> 3.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.19"
-  spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 1.72"
+  spec.add_development_dependency "rubocop-i18n", "~> 3.2"
+  spec.add_development_dependency "rubocop-performance", "~> 1.24"
+  spec.add_development_dependency "rubocop-rake", "~> 0.7.1"
+  spec.add_development_dependency "rubocop-rspec", "~> 3.5"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
   spec.add_development_dependency "webmock", "~> 3.9"
 end

--- a/lib/alexandria/export_library.rb
+++ b/lib/alexandria/export_library.rb
@@ -142,6 +142,8 @@ module Alexandria
     private
 
     ONIX_DTD_URL = "http://www.editeur.org/onix/2.1/reference/onix-international.dtd"
+    private_constant :ONIX_DTD_URL
+
     def to_onix_document
       doc = REXML::Document.new
       doc << REXML::XMLDecl.new

--- a/lib/alexandria/library_store.rb
+++ b/lib/alexandria/library_store.rb
@@ -46,7 +46,7 @@ module Alexandria
       FileUtils.mkdir_p(library.path)
       Dir.chdir(library.path) do
         Dir["*" + Library::EXT[:book]].each do |filename|
-          test[1] = filename if (test[0]).zero?
+          test[1] = filename if test[0].zero?
 
           unless File.size? test[1]
             handle_empty_book_file(test[1], ruined_books)

--- a/lib/alexandria/ui/ui_manager.rb
+++ b/lib/alexandria/ui/ui_manager.rb
@@ -11,7 +11,7 @@ require "alexandria/library_sort_order"
 
 module Alexandria
   module UI
-    # rubocop:disable Metrics/ClassLength:
+    # rubocop:disable Metrics/ClassLength
     class UIManager < BuilderBase
       attr_accessor :main_app, :actiongroup, :appbar, :prefs, :listview, :iconview,
                     :listview_model, :iconview_model, :filtered_model
@@ -1241,6 +1241,6 @@ module Alexandria
         @filtered_model.convert_path_to_child_path(filter_path) if filter_path
       end
     end
-    # rubocop:enable Metrics/ClassLength:
+    # rubocop:enable Metrics/ClassLength
   end
 end


### PR DESCRIPTION
- Bump rubocop dependencies
- Use the new rubocop plugins configuration syntax
- Fix new RuboCop offenses
