### PR TITLE
Support Ruby 3.2 and above

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
 
       - name: Run RuboCop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - 'lib/alexandria/default_preferences.rb'
     - 'pkg/**/*'
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/alexandria-book-collection-manager.gemspec
+++ b/alexandria-book-collection-manager.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "http://www.github.com/mvz/alexandria-book-collection-manager"
 
   spec.license = "GPL-2.0-or-later"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["rubygems_mfa_required"] = "true"
 

--- a/lib/alexandria/book_providers.rb
+++ b/lib/alexandria/book_providers.rb
@@ -168,8 +168,8 @@ module Alexandria
         end
       end
 
-      def add(*args)
-        self << Variable.new(@provider, *args)
+      def add(*)
+        self << Variable.new(@provider, *)
       end
 
       def [](obj)

--- a/lib/alexandria/export_format.rb
+++ b/lib/alexandria/export_format.rb
@@ -26,10 +26,10 @@ module Alexandria
       ]
     end
 
-    def invoke(library, sort_order, filename, *args)
+    def invoke(library, sort_order, filename, *)
       sorted = ExportLibrary.new(library, sort_order)
       log.debug { "Exporting library sorted by #{sort_order}" }
-      sorted.send(@message, filename, *args)
+      sorted.send(@message, filename, *)
     end
 
     def needs_preview?

--- a/lib/alexandria/preferences.rb
+++ b/lib/alexandria/preferences.rb
@@ -5,7 +5,6 @@
 # See the file README.md for authorship and licensing information.
 
 require "singleton"
-require "set"
 require "alexandria/default_preferences"
 
 module Alexandria

--- a/lib/alexandria/smart_library.rb
+++ b/lib/alexandria/smart_library.rb
@@ -275,8 +275,8 @@ module Alexandria
       class LeftOperand < Operand
         attr_accessor :book_selector
 
-        def initialize(book_selector, *args)
-          super(*args)
+        def initialize(book_selector, *)
+          super(*)
           @book_selector = book_selector
         end
       end

--- a/util/rake/fileinstall.rb
+++ b/util/rake/fileinstall.rb
@@ -29,7 +29,6 @@
 
 require "fileutils"
 require "pathname"
-require "set"
 require "rake/tasklib"
 
 # A file installer task, capable of installing into the system


### PR DESCRIPTION
- **Require Ruby 3.2 or higher**
- **Bump RuboCop target ruby version**
- **Autocorrect Style/ArgumentsForwarding**
- **Autocorrect Lint/RedundantRequireStatement**
- **Remove Ruby 3.1 from the CI matrix**
