### PR TITLE
Make protected methods private

### DIFF
--- a/lib/alexandria/models/library.rb
+++ b/lib/alexandria/models/library.rb
@@ -397,7 +397,7 @@ module Alexandria
       book.ident + (Library.jpeg?(cover(book)) ? ".jpg" : ".gif")
     end
 
-    protected
+    private
 
     def initialize(name, store = nil)
       @name = name

--- a/lib/alexandria/ui/smart_library_properties_dialog_base.rb
+++ b/lib/alexandria/ui/smart_library_properties_dialog_base.rb
@@ -78,7 +78,7 @@ module Alexandria
         new_rule.value = nil
       end
 
-      protected
+      private
 
       attr_reader :smart_library_rules
 


### PR DESCRIPTION
There is no need for these methods to be accesible to other objects of the same class.
