### PR TITLE
Fix custom provider preferences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -114,6 +114,10 @@ RSpec/DescribeClass:
     - 'spec/end_to_end/**/*_spec.rb'
 
 RSpec/ExampleLength:
+  CountAsOne:
+    - hash
+    - array
+    - heredoc
   Max: 8
   Exclude:
     - 'spec/end_to_end/**/*_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 group :development, :test do
   gem "gnome_app_driver", "~> 0.3.2"
+  gem "irb", "~> 1.16"
   gem "rake", "~> 13.0"
   gem "rspec", "~> 3.0"
   gem "rubocop", "~> 1.79"

--- a/lib/alexandria/book_providers.rb
+++ b/lib/alexandria/book_providers.rb
@@ -343,7 +343,7 @@ module Alexandria
           klass = @abstract_classes.find { |x| x.name.include?(klass_name) }
           next unless klass
 
-          fullname = @prefs.send(name.downcase + "_name")
+          fullname = @prefs.get_variable(name.downcase + "_name")
           next unless fullname
 
           instance = klass.new

--- a/lib/alexandria/preferences.rb
+++ b/lib/alexandria/preferences.rb
@@ -216,7 +216,7 @@ module Alexandria
       hash = {}
       vals = all_vals.split(/$/)
       vals.each do |val|
-        if /([a-z_]+) = (.*)/ =~ val
+        if /([-a-z0-9_]+) = (.*)/ =~ val
           hash[Regexp.last_match[1]] = discriminate(Regexp.last_match[2])
         end
       end

--- a/spec/alexandria/book_providers_spec.rb
+++ b/spec/alexandria/book_providers_spec.rb
@@ -7,5 +7,26 @@
 require "spec_helper"
 
 describe Alexandria::BookProviders do
-  it "should be less clever"
+  describe ".list" do
+    before do
+      Alexandria::Preferences.instance.set_variable :abstract_providers, []
+    end
+
+    it "includes the default set of providers" do
+      list = described_class.list
+      expect(list.map(&:fullname))
+        .to contain_exactly("Thalia (Germany)", "WorldCat", "Library of Congress (Usa)",
+                            "British Library", "Servizio Bibliotecario Nazionale (Italy)",
+                            "Douban (China)")
+    end
+
+    it "includes an added custom provider" do
+      instance = described_class.abstract_classes.first.new
+      instance.reinitialize("Foo Bar")
+      described_class.instance.update_priority
+
+      list = described_class.list
+      expect(list.last.fullname).to eq "Foo Bar"
+    end
+  end
 end

--- a/spec/alexandria/preferences_spec.rb
+++ b/spec/alexandria/preferences_spec.rb
@@ -39,13 +39,29 @@ describe Alexandria::Preferences do
     end
   end
 
-  it "allows setting known setting to false" do
-    instance.toolbar_visible = false
-    expect(instance.toolbar_visible).to be false
+  describe "setter generated from default values" do
+    it "allows setting known setting to false" do
+      instance.toolbar_visible = false
+      expect(instance.toolbar_visible).to be false
+    end
+
+    it "resets known setting by setting to nil" do
+      instance.toolbar_visible = nil
+      expect(instance.toolbar_visible).to be true
+    end
   end
 
-  it "resets known setting by setting to nil" do
-    instance.toolbar_visible = nil
-    expect(instance.toolbar_visible).to be true
+  describe "private method #gconftool_values_to_hash" do
+    it "works with custom z3950 providers" do
+      all_vals = <<~SETTINGS
+        z3950_12345_name = Foo
+        z3950_-8765_name = Bar
+      SETTINGS
+      result = instance.send :gconftool_values_to_hash, all_vals
+      expect(result).to eq({
+                             "z3950_12345_name" => "Foo",
+                             "z3950_-8765_name" => "Bar"
+                           })
+    end
   end
 end


### PR DESCRIPTION
This fixes issues with settings for custom providers which caused that feature to be unusable.

- **Add IRB development dependency**
- **Fix fetching of custom provider name**
- **Correctly load custom provider preference at start-up**
